### PR TITLE
refactor: standardize build flag to BUILD_WITH_COMMON_SYSTEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ option(MONITORING_BUILD_EXAMPLES "Build example programs" ON)
 option(MONITORING_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(MONITORING_USE_THREAD_SYSTEM "Enable thread_system integration" OFF)
 option(MONITORING_USE_LOGGER_SYSTEM "Enable logger_system integration" OFF)
-option(MONITORING_USE_COMMON_SYSTEM "Enable common_system integration" ON)
+option(BUILD_WITH_COMMON_SYSTEM "Enable common_system integration" ON)
 option(ENABLE_ASAN "Enable AddressSanitizer" OFF)
 option(ENABLE_TSAN "Enable ThreadSanitizer" OFF)
 option(ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer" OFF)
@@ -73,13 +73,13 @@ target_include_directories(monitoring_system_interface
         $<INSTALL_INTERFACE:include>
 )
 
-if(MONITORING_USE_COMMON_SYSTEM)
+if(BUILD_WITH_COMMON_SYSTEM)
     message(STATUS "Monitoring System: Enabling common_system integration")
     target_include_directories(monitoring_system_interface
         INTERFACE
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common_system/include>
     )
-    target_compile_definitions(monitoring_system_interface INTERFACE MONITORING_USE_COMMON_SYSTEM USE_COMMON_SYSTEM)
+    target_compile_definitions(monitoring_system_interface INTERFACE BUILD_WITH_COMMON_SYSTEM)
 endif()
 
 # Set compile features

--- a/README.md
+++ b/README.md
@@ -763,6 +763,7 @@ cmake -B build \
 
 # Integration options
 cmake -B build \
+  -DBUILD_WITH_COMMON_SYSTEM=ON \
   -DTHREAD_SYSTEM_INTEGRATION=ON \
   -DLOGGER_SYSTEM_INTEGRATION=ON
 ```

--- a/include/kcenon/monitoring/adapters/common_system_adapter.h
+++ b/include/kcenon/monitoring/adapters/common_system_adapter.h
@@ -13,7 +13,7 @@ All rights reserved.
 #include <chrono>
 
 // Check if common_system is available
-#ifdef USE_COMMON_SYSTEM
+#ifdef BUILD_WITH_COMMON_SYSTEM
 #include <kcenon/common/interfaces/monitoring_interface.h>
 #include <kcenon/common/patterns/result.h>
 #endif
@@ -25,7 +25,7 @@ All rights reserved.
 namespace monitoring_system {
 namespace adapters {
 
-#ifdef USE_COMMON_SYSTEM
+#ifdef BUILD_WITH_COMMON_SYSTEM
 
 /**
  * @brief Adapter to expose monitoring_system as common::interfaces::IMonitor
@@ -349,7 +349,7 @@ public:
     }
 };
 
-#endif // USE_COMMON_SYSTEM
+#endif // BUILD_WITH_COMMON_SYSTEM
 
 } // namespace adapters
 } // namespace monitoring_system


### PR DESCRIPTION
## Summary
- Standardizes the build configuration flag from `USE_COMMON_SYSTEM` to `BUILD_WITH_COMMON_SYSTEM`
- Ensures consistency across the entire ecosystem of related projects
- Updates documentation to reflect the new build option

## Changes
- **CMakeLists.txt**: Replaced `USE_COMMON_SYSTEM` with `BUILD_WITH_COMMON_SYSTEM` throughout the build configuration
- **include/kcenon/monitoring/adapters/common_system_adapter.h**: Updated preprocessor directives to use the new flag
- **README.md**: Added `BUILD_WITH_COMMON_SYSTEM` to the integration options documentation

## Rationale
This change aligns with ecosystem-wide standardization efforts where all projects are adopting the `BUILD_WITH_COMMON_SYSTEM` naming convention. The `BUILD_` prefix clearly indicates this is a build-time configuration option, following CMake best practices.

## Impact
- **API Compatibility**: No changes to public APIs
- **Build Configuration**: Projects using explicit `-DUSE_COMMON_SYSTEM` will need to update to `-DBUILD_WITH_COMMON_SYSTEM`
- **Default Behavior**: Maintains the same default settings

## Testing
- Verified successful build with `BUILD_WITH_COMMON_SYSTEM=ON`
- Verified successful build with `BUILD_WITH_COMMON_SYSTEM=OFF`
- All monitoring functionality remains intact
- Integration with common_system works as expected

## Related Changes
This is part of a coordinated effort across multiple repositories:
- thread_system: PR #23
- logger_system: PR #14
- All repositories in the ecosystem are adopting this standardized naming