### PR TITLE
feat: implement IMonitor interface in performance_monitor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,22 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # Find dependencies
 find_package(Threads REQUIRED)
 
+# common_system dependency
+if(BUILD_WITH_COMMON_SYSTEM)
+    find_package(common_system CONFIG QUIET)
+    if(NOT common_system_FOUND)
+        # Check sibling directory
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../common_system/include/kcenon/common/interfaces/monitoring_interface.h")
+            message(STATUS "Found common_system as sibling directory")
+        else()
+            message(WARNING "common_system integration requested but not found - disabling")
+            set(BUILD_WITH_COMMON_SYSTEM OFF)
+        endif()
+    else()
+        message(STATUS "Found common_system package")
+    endif()
+endif()
+
 # Optional dependencies
 if(MONITORING_USE_THREAD_SYSTEM)
     find_package(thread_system CONFIG)
@@ -79,7 +95,16 @@ if(BUILD_WITH_COMMON_SYSTEM)
         INTERFACE
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common_system/include>
     )
-    target_compile_definitions(monitoring_system_interface INTERFACE BUILD_WITH_COMMON_SYSTEM)
+    target_compile_definitions(monitoring_system_interface
+        INTERFACE
+            BUILD_WITH_COMMON_SYSTEM
+            MONITORING_USING_COMMON_INTERFACES
+    )
+
+    # Link common_system if found as package
+    if(common_system_FOUND)
+        target_link_libraries(monitoring_system_interface INTERFACE kcenon::common_system)
+    endif()
 endif()
 
 # Set compile features

--- a/src/core/performance_monitor.cpp
+++ b/src/core/performance_monitor.cpp
@@ -236,13 +236,13 @@ common::VoidResult performance_monitor::record_metric(const std::string& name, d
     auto result = profiler_.record_sample(name, duration, true);
 
     if (!result) {
-        return common::VoidResult::error(
+        return common::error_info(
             static_cast<int>(result.get_error().code),
             result.get_error().message
         );
     }
 
-    return common::VoidResult::success();
+    return std::monostate{};
 }
 
 common::VoidResult performance_monitor::record_metric(
@@ -260,7 +260,7 @@ common::Result<common::interfaces::metrics_snapshot> performance_monitor::get_me
     auto snapshot_result = collect();
 
     if (!snapshot_result) {
-        return common::Result<common::interfaces::metrics_snapshot>::error(
+        return common::error_info(
             static_cast<int>(snapshot_result.get_error().code),
             snapshot_result.get_error().message
         );
@@ -282,7 +282,7 @@ common::Result<common::interfaces::metrics_snapshot> performance_monitor::get_me
         common_snapshot.metrics.push_back(common_metric);
     }
 
-    return common::Result<common::interfaces::metrics_snapshot>::success(common_snapshot);
+    return common_snapshot;
 }
 
 common::Result<common::interfaces::health_check_result> performance_monitor::check_health() {
@@ -298,7 +298,7 @@ common::Result<common::interfaces::health_check_result> performance_monitor::che
         result.check_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
             end_time - start_time
         );
-        return common::Result<common::interfaces::health_check_result>::success(result);
+        return result;
     }
 
     // Check thresholds
@@ -318,14 +318,14 @@ common::Result<common::interfaces::health_check_result> performance_monitor::che
         end_time - start_time
     );
 
-    return common::Result<common::interfaces::health_check_result>::success(result);
+    return result;
 }
 
 common::VoidResult performance_monitor::reset() {
     // Clear all profiler samples
     profiler_.clear_all_samples();
 
-    return common::VoidResult::success();
+    return std::monostate{};
 }
 #endif // MONITORING_USING_COMMON_INTERFACES
 


### PR DESCRIPTION
## Summary

Implement `common::interfaces::IMonitor` interface in `performance_monitor` class, enabling monitoring_system to be used as a drop-in replacement for any code expecting common_system monitoring interfaces.

This PR implements Phase 2.3 (Tasks 2.3.2-2.3.3) of the CIRCULAR_DEPENDENCY_RESOLUTION_ROADMAP.md.

## Changes

### 1. Common System Dependency
- Added explicit `find_package(common_system)` to CMakeLists.txt
- Added `MONITORING_USING_COMMON_INTERFACES` compile definition
- Configured conditional build with common_system support
- Link common_system package when available

### 2. IMonitor Interface Implementation
- Added conditional multiple inheritance: `performance_monitor` now inherits from both `metrics_collector` and `common::interfaces::IMonitor`
- Implemented 5 IMonitor interface methods:
  - `record_metric(name, value)` - records metrics
  - `record_metric(name, value, tags)` - records metrics with tags
  - `get_metrics()` - returns metrics snapshot
  - `check_health()` - performs health check
  - `reset()` - resets all metrics

### 3. Type Conversion Layer
- Converts `monitoring_system::metrics_snapshot` to `common::interfaces::metrics_snapshot`
- Converts `monitoring_system::metric_value` to `common::interfaces::metric_value`
- Maps internal health checks to common health_check_result format
- Delegates to existing profiler and system_monitor implementations

### 4. Result Type Fixes
- Fixed Result type usage to match `std::variant<T, error_info>` pattern
- Updated success returns to use direct value or `std::monostate{}`
- Updated error returns to use `common::error_info`
- Proper error handling and propagation

## Architecture

```cpp
#ifdef MONITORING_USING_COMMON_INTERFACES
class performance_monitor 
    : public metrics_collector,           // Existing interface
      public common::interfaces::IMonitor // New common interface
#else
class performance_monitor : public metrics_collector
#endif
```

This dual-inheritance approach ensures:
- ✅ Backward compatibility with existing code
- ✅ Forward compatibility with common_system
- ✅ Zero overhead when not using common interfaces
- ✅ Compile-time selection via preprocessor

## Build Status

✅ **All targets build successfully:**
- monitoring_system library
- All examples (result_pattern, distributed_tracing, basic_monitoring, health_reliability)
- All tests (monitoring_system_tests)

No warnings, no errors.

## Breaking Changes

**None** - Changes are entirely additive:
- Uses conditional compilation (`#ifdef MONITORING_USING_COMMON_INTERFACES`)
- Existing code continues to work unchanged
- New interface only active when explicitly enabled
- No modifications to existing APIs

## Usage Example

```cpp
// Can now use performance_monitor as IMonitor
auto monitor = std::make_shared<performance_monitor>("my_monitor");

// IMonitor interface
monitor->record_metric("cpu_usage", 45.2);
monitor->record_metric("memory_mb", 1024.5, {{"host", "server1"}});

auto metrics_result = monitor->get_metrics();
if (std::holds_alternative<common::interfaces::metrics_snapshot>(metrics_result)) {
    auto snapshot = std::get<common::interfaces::metrics_snapshot>(metrics_result);
    // Process metrics...
}

auto health_result = monitor->check_health();
if (std::holds_alternative<common::interfaces::health_check_result>(health_result)) {
    auto health = std::get<common::interfaces::health_check_result>(health_result);
    if (health.is_healthy()) {
        // System is healthy
    }
}
```

## Testing

- [x] Library builds successfully with common_system integration
- [x] All examples compile and run
- [x] All tests pass
- [x] No compiler warnings
- [x] IMonitor interface methods callable
- [x] Type conversions work correctly

## Performance Impact

- **No runtime overhead** when `MONITORING_USING_COMMON_INTERFACES` is not defined
- **Minimal overhead** when enabled (only type conversions, no additional allocations)
- Existing `metrics_collector` interface remains unchanged

## Related

- Implements: CIRCULAR_DEPENDENCY_RESOLUTION_ROADMAP.md Phase 2.3 Tasks 2.3.2-2.3.3
- Related PR: [logger_system interface migration](https://github.com/kcenon/logger_system/pull/17)
- Dependency: common_system interfaces
- Resolves: Circular dependency between monitoring_system and logger_system

## Checklist

- [x] Code follows project style guidelines
- [x] All targets build successfully
- [x] All tests pass
- [x] No compiler warnings
- [x] Backward compatibility maintained
- [x] Documentation updated in code
- [x] CMake configuration updated
- [x] Commit messages follow convention

---

**Commits:**
- b4275980: build(monitoring): add explicit common_system dependency
- 316d13a0: feat(monitoring): implement IMonitor interface in performance_monitor
- 8f0b6f86: fix(monitoring): correct Result type usage in IMonitor implementation