### PR TITLE
refactor: Remove circular dependency between monitoring_system and logger_system

### DIFF
--- a/include/kcenon/monitoring/adapters/logger_system_adapter.h
+++ b/include/kcenon/monitoring/adapters/logger_system_adapter.h
@@ -26,45 +26,127 @@
 #include "../core/result_types.h"
 #include "../interfaces/metric_types_adapter.h"
 
-// Optional: integrate with logger_system when available
-#ifdef BUILD_WITH_LOGGER_SYSTEM
-#  include <kcenon/logger/core/logger.h>
+// Use common_system interfaces for logger integration
+#ifdef BUILD_WITH_COMMON_SYSTEM
+#  include <kcenon/common/interfaces/logger_interface.h>
+#  include <kcenon/common/interfaces/monitoring_interface.h>
 #endif
 
 namespace monitoring_system {
 
+/**
+ * @brief Logger system adapter using dependency injection
+ *
+ * This adapter uses common::interfaces::ILogger instead of concrete logger_system
+ * classes, removing compile-time dependency on logger_system.
+ */
 class logger_system_adapter {
 public:
-    explicit logger_system_adapter(std::shared_ptr<event_bus> bus)
-        : bus_(std::move(bus)) {}
-
-    bool is_logger_system_available() const {
-#ifdef BUILD_WITH_LOGGER_SYSTEM
-        return true;
+    /**
+     * @brief Constructor with optional logger injection
+     * @param bus Event bus for monitoring events
+     * @param logger Optional logger instance (any ILogger implementation)
+     */
+    explicit logger_system_adapter(
+        std::shared_ptr<event_bus> bus,
+#ifdef BUILD_WITH_COMMON_SYSTEM
+        std::shared_ptr<common::interfaces::ILogger> logger = nullptr
 #else
-        return false;
+        std::nullptr_t logger = nullptr
 #endif
+    ) : bus_(std::move(bus)), logger_(std::move(logger)) {}
+
+    /**
+     * @brief Check if logger is available
+     */
+    bool is_logger_system_available() const {
+        return logger_ != nullptr;
     }
 
-    // One‑shot collection. Empty when logger_system is not integrated.
+    /**
+     * @brief Set or replace the logger instance
+     * @param logger New logger instance
+     */
+#ifdef BUILD_WITH_COMMON_SYSTEM
+    void set_logger(std::shared_ptr<common::interfaces::ILogger> logger) {
+        logger_ = std::move(logger);
+    }
+
+    /**
+     * @brief Get the current logger instance
+     */
+    std::shared_ptr<common::interfaces::ILogger> get_logger() const {
+        return logger_;
+    }
+#endif
+
+    /**
+     * @brief Collect metrics from logger if available
+     */
     result<std::vector<metric>> collect_metrics() {
         std::vector<metric> out;
-#ifdef BUILD_WITH_LOGGER_SYSTEM
-        // If needed, convert logger metrics to monitoring metrics here.
+#ifdef BUILD_WITH_COMMON_SYSTEM
+        if (logger_) {
+            // If logger implements IMonitorable, collect its metrics
+            auto monitorable = std::dynamic_pointer_cast<common::interfaces::IMonitorable>(logger_);
+            if (monitorable) {
+                auto metrics_result = monitorable->get_monitoring_data();
+                if (std::holds_alternative<common::interfaces::metrics_snapshot>(metrics_result)) {
+                    const auto& snapshot = std::get<common::interfaces::metrics_snapshot>(metrics_result);
+                    // Convert to monitoring_system metric format
+                    for (const auto& m : snapshot.metrics) {
+                        metric converted;
+                        converted.name = m.name;
+                        converted.value = m.value;
+                        converted.timestamp = m.timestamp;
+                        out.push_back(converted);
+                    }
+                }
+            }
+        }
 #endif
         return make_success(std::move(out));
     }
 
-    // Register a logger instance by name (no‑op in fallback mode)
+    /**
+     * @brief Register a logger instance by name
+     */
     result_void register_logger(const std::string& /*name*/) {
+        // Logger is now provided via DI, not registered by name
         return result_void::success();
     }
 
-    // Convenience method for examples/tests; returns 0.0 when unavailable
-    double get_current_log_rate() const { return 0.0; }
+    /**
+     * @brief Get current log rate (if logger supports metrics)
+     */
+    double get_current_log_rate() const {
+#ifdef BUILD_WITH_COMMON_SYSTEM
+        if (logger_) {
+            auto monitorable = std::dynamic_pointer_cast<common::interfaces::IMonitorable>(logger_);
+            if (monitorable) {
+                auto metrics_result = monitorable->get_monitoring_data();
+                if (std::holds_alternative<common::interfaces::metrics_snapshot>(metrics_result)) {
+                    const auto& snapshot = std::get<common::interfaces::metrics_snapshot>(metrics_result);
+                    for (const auto& m : snapshot.metrics) {
+                        if (m.name.find("messages_logged") != std::string::npos ||
+                            m.name.find("log_rate") != std::string::npos) {
+                            return m.value;
+                        }
+                    }
+                }
+            }
+        }
+#endif
+        return 0.0;
+    }
 
 private:
     std::shared_ptr<event_bus> bus_;
+#ifdef BUILD_WITH_COMMON_SYSTEM
+    std::shared_ptr<common::interfaces::ILogger> logger_;
+#else
+    std::nullptr_t logger_ = nullptr;
+#endif
 };
 
 } // namespace monitoring_system


### PR DESCRIPTION
## Summary
This PR resolves the circular dependency between `monitoring_system` and `logger_system` by adopting interface-based dependency injection pattern following the CIRCULAR_DEPENDENCY_RESOLUTION_ROADMAP.

## Changes Made

### logger_system_adapter Refactoring
- **Removed concrete dependency**: Replaced `#include <kcenon/logger/core/logger.h>` with interface includes
- **Interface-based design**: Now uses `common::interfaces::ILogger` instead of concrete logger classes
- **Dependency injection**: Logger instance is now injected via constructor parameter
- **Runtime polymorphism**: Uses `dynamic_cast` to `IMonitorable` for optional metrics collection

### Technical Details
- Changed from `BUILD_WITH_LOGGER_SYSTEM` to `BUILD_WITH_COMMON_SYSTEM` conditional compilation
- Added `set_logger()` and `get_logger()` methods for runtime logger configuration
- Enhanced `collect_metrics()` to work with any `ILogger` implementation that supports `IMonitorable`
- Improved `get_current_log_rate()` to extract metrics from monitorable loggers

## Benefits
- **Eliminates compile-time circular dependency** between monitoring_system and logger_system
- **Loose coupling**: monitoring_system no longer depends on logger_system headers
- **Flexibility**: Any ILogger implementation can be used, not just logger_system
- **Maintainability**: Cleaner separation of concerns with DI pattern

## Testing
- Built successfully with `BUILD_WITH_COMMON_SYSTEM=ON`
- No build warnings or errors
- Backward compatible interface maintained

## Related
- Follows Phase 2.3 of CIRCULAR_DEPENDENCY_RESOLUTION_ROADMAP.md
- Complements existing logger_system IMonitorable implementation