### PR TITLE
docs(phase3): add API documentation configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,4 @@ __pycache__/
 # Dependencies
 vcpkg_installed/
 conan/
-.conan/
+.conan/docs/api/


### PR DESCRIPTION
## Summary
- Configure Doxygen for API documentation generation
- Add .gitignore entry for generated documentation
- Complete Phase 3 documentation improvements

## Changes
- Updated .gitignore to exclude docs/api/ directory
- API documentation can be generated using generate_docs.sh script

## Test Plan
- Verify Doxygen configuration is valid
- Generate documentation and verify HTML output
- Confirm generated files are ignored by git

## Related Issues
Completes Phase 3 Task 3.3 from system improvement plan