### PR TITLE
fix(tests): use angle brackets for system includes

### DIFF
--- a/tests/thread_safety_tests.cpp
+++ b/tests/thread_safety_tests.cpp
@@ -6,9 +6,9 @@ All rights reserved.
 *****************************************************************************/
 
 #include <gtest/gtest.h>
-#include "kcenon/monitoring/core/event_bus.h"
-#include "kcenon/monitoring/collectors/metric_collector.h"
-#include "kcenon/monitoring/utils/time_series.h"
+#include <kcenon/monitoring/core/event_bus.h>
+#include <kcenon/monitoring/collectors/metric_collector.h>
+#include <kcenon/monitoring/utils/time_series.h>
 
 #include <thread>
 #include <vector>


### PR DESCRIPTION
## Summary

Fixes compilation errors in `thread_safety_tests.cpp` by using angle brackets for system-level includes.

## Problem

The sanitizer CI workflow was failing with:
```
fatal error: 'kcenon/monitoring/collectors/metric_collector.h' file not found
```

The file was using quotes (`"kcenon/..."`) for includes, which doesn't work with the project's CMake include directory configuration.

## Solution

- Changed `#include "kcenon/monitoring/..."` to `#include <kcenon/monitoring/...>`
- Aligns with include style used in other test files in the project

## Testing

- [ ] CI sanitizer workflow should now compile successfully

## Related Issues

- Part of Phase 1 completion (Thread Safety)
- Resolves CI build failures blocking Phase 1 exit criteria verification