### PR TITLE
Fix unused lambda capture warnings in integration tests

### DIFF
--- a/integration_tests/performance/monitoring_performance_test.cpp
+++ b/integration_tests/performance/monitoring_performance_test.cpp
@@ -200,8 +200,8 @@ TEST_F(MonitoringPerformanceTest, ConcurrentCollectionPerformance) {
     auto start = std::chrono::high_resolution_clock::now();
 
     for (size_t t = 0; t < num_threads; ++t) {
-        threads.emplace_back([this, metrics_per_thread, &total_collected, t]() {
-            for (size_t i = 0; i < metrics_per_thread; ++i) {
+        threads.emplace_back([this, &total_collected, t, metrics = metrics_per_thread]() {
+            for (size_t i = 0; i < metrics; ++i) {
                 RecordSample("concurrent_perf_" + std::to_string(t),
                            std::chrono::microseconds(100));
                 total_collected.fetch_add(1);

--- a/integration_tests/scenarios/metrics_collection_test.cpp
+++ b/integration_tests/scenarios/metrics_collection_test.cpp
@@ -216,8 +216,8 @@ TEST_F(MetricsCollectionTest, ConcurrentMetricUpdates) {
     std::vector<std::thread> threads;
 
     for (size_t t = 0; t < num_threads; ++t) {
-        threads.emplace_back([this, samples_per_thread]() {
-            for (size_t i = 0; i < samples_per_thread; ++i) {
+        threads.emplace_back([this, samples = samples_per_thread]() {
+            for (size_t i = 0; i < samples; ++i) {
                 auto duration = std::chrono::microseconds(100 + i);
                 RecordSample("concurrent_test", duration);
             }


### PR DESCRIPTION
## Summary

This PR resolves compiler warnings about unused lambda captures in integration test files.

## Changes

- **monitoring_performance_test.cpp**: Replace implicit capture with init-capture syntax
  -  → 
- **metrics_collection_test.cpp**: Replace implicit capture with init-capture syntax  
  -  → 

## Technical Details

The compiler was generating warnings:
```
warning: lambda capture 'X' is not required to be captured for this use [-Wunused-lambda-capture]
```

Using C++14 init-capture syntax makes the capture intent explicit and eliminates these warnings. The init-capture creates a new variable within the lambda scope, clearly indicating that the value is being copied for use inside the lambda.

## Testing

- ✅ Build completes successfully with zero warnings
- ✅ All integration tests pass
- ✅ No functional changes to test behavior

## Impact

- Removes compiler noise from build output
- Improves code clarity by making lambda capture intent explicit
- Prepares codebase for stricter warning-as-error builds