### PR TITLE
Fix CMake target name conflict for integration tests

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -67,7 +67,7 @@ gtest_discover_tests(monitoring_integration_tests
 )
 
 # Add custom target to run integration tests
-add_custom_target(run_integration_tests
+add_custom_target(monitoring_run_integration_tests
     COMMAND monitoring_integration_tests
     DEPENDS monitoring_integration_tests
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -92,7 +92,7 @@ if(ENABLE_COVERAGE)
             COMMAND lcov --capture --directory . --output-file coverage/integration.info --ignore-errors mismatch --ignore-errors inconsistent
             COMMAND lcov --remove coverage/integration.info '/usr/*' '*/tests/*' '*/examples/*' --output-file coverage/integration_filtered.info --ignore-errors unused
             COMMAND genhtml coverage/integration_filtered.info --output-directory coverage/integration_html --ignore-errors source
-            DEPENDS run_integration_tests
+            DEPENDS monitoring_run_integration_tests
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
             COMMENT "Generating integration test coverage report"
         )


### PR DESCRIPTION
## Summary
This PR renames the custom integration test target to prevent CMake target name conflicts when monitoring_system is used alongside other systems in a parent project.

## Problem
When multiple systems are included as subdirectories in a parent project, each defining a custom target named `run_integration_tests` causes CMake to fail with:
```
CMake Error: add_custom_target cannot create target "run_integration_tests" 
because another target with the same name already exists.
```

This is common when integrating monitoring_system with other sibling systems like database_system, network_system, etc., which may also define similarly named targets.

## Solution
Renamed the custom target with a system-specific prefix:
- `run_integration_tests` → `monitoring_run_integration_tests`

Also updated the dependency reference in the coverage target to maintain consistency.

## Impact
**What changes:**
- Custom target name for running integration tests

**What remains unchanged:**
- Test executable name (`monitoring_integration_tests`)
- Test functionality and behavior
- Test discovery and CTest integration
- All test content and coverage

**Compatibility:**
- ✅ Standalone builds work identically (can use `make monitoring_run_integration_tests`)
- ✅ No breaking changes for test execution
- ✅ Parent projects can now include monitoring_system alongside other systems
- ⚠️ Users who explicitly invoke `make run_integration_tests` need to update to `make monitoring_run_integration_tests`

## Testing
- ✅ Standalone build: Integration tests run successfully with new target name
- ✅ Multi-system build: No CMake target conflicts when combined with other systems
- ✅ CTest integration: `ctest` continues to discover and run all tests normally