### PR TITLE
Add automatic GTest download using FetchContent

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -8,9 +8,24 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Find Google Test
-# Note: If not found, parent CMakeLists.txt may provide it via FetchContent
+# Find or fetch Google Test
 find_package(GTest QUIET)
+
+if(NOT GTest_FOUND)
+    message(STATUS "GTest not found - fetching from GitHub")
+    include(FetchContent)
+    FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.14.0
+        GIT_SHALLOW TRUE
+    )
+    # Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+    message(STATUS "GTest fetched successfully")
+endif()
+
 include(GoogleTest)
 
 # Include directories
@@ -33,13 +48,25 @@ add_executable(monitoring_integration_tests
 )
 
 # Link against monitoring_system and Google Test
-target_link_libraries(monitoring_integration_tests
-    PRIVATE
-        monitoring_system
-        GTest::GTest
-        GTest::Main
-        Threads::Threads
-)
+if(TARGET GTest::GTest)
+    # Using system-installed GTest
+    target_link_libraries(monitoring_integration_tests
+        PRIVATE
+            monitoring_system
+            GTest::GTest
+            GTest::Main
+            Threads::Threads
+    )
+else()
+    # Using FetchContent GTest
+    target_link_libraries(monitoring_integration_tests
+        PRIVATE
+            monitoring_system
+            gtest
+            gtest_main
+            Threads::Threads
+    )
+endif()
 
 # Add compile options
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")


### PR DESCRIPTION
## Summary

This PR integrates FetchContent to automatically download and build GoogleTest when it is not found on the system, eliminating the need for manual GTest installation.

## Changes

- Added FetchContent declaration for GoogleTest v1.14.0
- Implemented conditional linking for both system GTest and FetchContent GTest
- Integration tests now build automatically without external dependencies

## Benefits

- **Simplified Setup**: No manual GTest installation required
- **Consistency**: Same test environment across different machines
- **CI/CD Ready**: Streamlined pipeline without dependency installation steps
- **Developer Experience**: Faster onboarding for new contributors

## Testing

- ✅ Built successfully with system GTest
- ✅ Built successfully without GTest (auto-download)
- ✅ Integration tests pass in both scenarios

## Related Issues

Addresses the issue where integration tests were skipped when GTest was not installed on the system.