### PR TITLE
Fix invalid header includes in common_monitor_adapter

### DIFF
--- a/include/kcenon/monitoring/adapters/common_monitor_adapter.h
+++ b/include/kcenon/monitoring/adapters/common_monitor_adapter.h
@@ -19,10 +19,12 @@ All rights reserved.
 #include <kcenon/common/patterns/result.h>
 #endif
 
-#include "../monitor.h"
-#include "../metrics_collector.h"
-#include "../health_monitor.h"
+// Include actual monitoring_system headers
+#include <kcenon/monitoring/core/performance_monitor.h>
+#include <kcenon/monitoring/health/health_monitor.h>
+#include <kcenon/monitoring/interfaces/monitoring_interface.h>
 
+namespace kcenon {
 namespace monitoring {
 namespace adapters {
 
@@ -418,3 +420,4 @@ public:
 
 } // namespace adapters
 } // namespace monitoring
+} // namespace kcenon


### PR DESCRIPTION
## Summary

Fixes compilation-blocking issues in `common_monitor_adapter.h` caused by non-existent header includes and incorrect namespace declaration.

## Problem

**Invalid Header Includes:**
```cpp
#include "../monitor.h"              // Does not exist
#include "../metrics_collector.h"   // Does not exist
#include "../health_monitor.h"      // Wrong path
```

**Incorrect Namespace:**
```cpp
namespace monitoring {    // Should be kcenon::monitoring
namespace adapters {
```

**Impact:**
- Adapter cannot be compiled when `BUILD_WITH_COMMON_SYSTEM` is enabled
- Breaks integration between monitoring_system and common_system
- Namespace inconsistency with rest of monitoring_system codebase

## Solution

**Fixed Include Paths:**
```cpp
#include <kcenon/monitoring/core/performance_monitor.h>
#include <kcenon/monitoring/health/health_monitor.h>
#include <kcenon/monitoring/interfaces/monitoring_interface.h>
```

**Corrected Namespace:**
```cpp
namespace kcenon {
namespace monitoring {
namespace adapters {
```

## Changes

**File: `include/kcenon/monitoring/adapters/common_monitor_adapter.h`**

1. Replaced three invalid includes with correct monitoring_system headers
2. Fixed namespace declaration to match include path convention (`kcenon::monitoring::`)
3. Added proper closing namespace comment

## Impact

- Resolves compilation errors when `BUILD_WITH_COMMON_SYSTEM=ON`
- Enables proper integration with common_system interfaces
- Maintains namespace consistency across all monitoring_system components
- No changes to adapter API or behavior

## Testing

- [ ] Verify compilation with `BUILD_WITH_COMMON_SYSTEM=ON`
- [ ] Confirm adapter classes can be instantiated
- [ ] Check integration tests pass

## Related Changes

- common_system PR #54: Namespace alias for backward compatibility
- logger_system PR (pending): Include location fix
- Identified during cross-system integration review