### PR TITLE
Sprint 1: Remove hardcoded developer paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,10 +73,9 @@ if(BUILD_WITH_COMMON_SYSTEM)
 find_package(common_system CONFIG QUIET)
 if(NOT common_system_FOUND)
     # Check for common_system in multiple locations
-    # Priority: Sources/ directory (macOS/Linux), then relative paths as fallback
+    # Priority: Environment variable, then relative paths as fallback
     set(_MONITORING_COMMON_PATHS
-        "/Users/dongcheolshin/Sources/common_system/include"
-        "/home/$ENV{USER}/Sources/common_system/include"
+        "$ENV{COMMON_SYSTEM_ROOT}/include"
         "${CMAKE_CURRENT_SOURCE_DIR}/../common_system/include"
         "${CMAKE_CURRENT_SOURCE_DIR}/common_system/include"
     )


### PR DESCRIPTION
## Summary

This PR improves build portability for monitoring_system by removing hardcoded user-specific paths.

### Changes

#### Remove Hardcoded Developer Paths
- Removed hardcoded `/Users/dongcheolshin/Sources` paths
- Removed hardcoded `/home/$USER/Sources` paths
- Uses `COMMON_SYSTEM_ROOT` environment variable as primary search method
- Kept relative path fallbacks for sibling directory layout

### Impact

- **Portability**: Builds work on any development machine
- **Flexibility**: Users can set `COMMON_SYSTEM_ROOT` or use sibling directory layout
- **CI/CD**: Better compatibility across build environments

### Testing

- [x] CMake configuration properly detects common_system dependency

See IMPROVEMENT_PLAN.md for detailed analysis.