### PR TITLE
Fix CMake install paths to match actual directory structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,8 +311,8 @@ install(TARGETS monitoring_system monitoring_system_interface
     EXPORT monitoring_system_targets
 )
 
-install(DIRECTORY sources/monitoring
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+install(DIRECTORY include/kcenon/monitoring
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon
     FILES_MATCHING PATTERN "*.h"
 )
 
@@ -340,8 +340,8 @@ write_basic_package_version_file(
 # Install adapter headers if BUILD_WITH_COMMON_SYSTEM is enabled
 if(BUILD_WITH_COMMON_SYSTEM)
     install(FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/monitoring/adapters/common_monitor_adapter.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/monitoring/adapters
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/common_monitor_adapter.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon/monitoring/adapters
         COMPONENT Development
     )
 endif()


### PR DESCRIPTION
## Problem
CMake install commands were referencing incorrect paths that don't exist in the repository, causing installation failures in CI builds.

### Error in CI
```
CMake Error at build/cmake_install.cmake:76 (file):
  file INSTALL cannot find
  "deps/monitoring_system/include/monitoring/adapters/common_monitor_adapter.h":
  No such file or directory.
```

## Root Cause

**Line 314**: `install(DIRECTORY sources/monitoring`
- ❌ The `sources/` directory doesn't exist
- ✅ Headers are actually in `include/kcenon/monitoring/`

**Line 343**: `include/monitoring/adapters/common_monitor_adapter.h`
- ❌ Missing `kcenon/` prefix in path
- ✅ Actual file: `include/kcenon/monitoring/adapters/common_monitor_adapter.h`

## Changes

### 1. Main Header Installation (lines 314-317)
```diff
-install(DIRECTORY sources/monitoring
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+install(DIRECTORY include/kcenon/monitoring
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon
     FILES_MATCHING PATTERN "*.h"
 )
```

### 2. Adapter Header Installation (lines 343-344)
```diff
 if(BUILD_WITH_COMMON_SYSTEM)
     install(FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/monitoring/adapters/common_monitor_adapter.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/monitoring/adapters
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/common_monitor_adapter.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon/monitoring/adapters
         COMPONENT Development
     )
 endif()
```

## Impact

✅ Fixes CI installation failures in database_system builds
✅ Headers install to correct location: `<prefix>/include/kcenon/monitoring/`
✅ Maintains consistency with other kcenon system libraries
✅ No breaking changes for code using `#include <kcenon/monitoring/...>`

## Directory Structure

**Actual repository structure:**
```
include/
└── kcenon/
    └── monitoring/
        ├── adapters/
        │   └── common_monitor_adapter.h
        ├── core/
        └── ...
```

**Install destination after fix:**
```
<prefix>/include/kcenon/monitoring/...
```

## Related Issues

Fixes installation failures in:
- database_system CI builds
- Any downstream project building monitoring_system with dependencies