### PR TITLE
refactor: use common::ok() instead of result_void{} for success returns

### DIFF
--- a/include/kcenon/monitoring/exporters/metric_exporters.h
+++ b/include/kcenon/monitoring/exporters/metric_exporters.h
@@ -110,7 +110,7 @@ struct metric_export_config {
                              "Queue size must be at least batch size", "monitoring_system").to_common_error());
         }
 
-        return result_void{};
+        return common::ok();
     }
 };
 
@@ -270,12 +270,12 @@ public:
     /**
      * @brief Start the exporter (for pull-based systems)
      */
-    virtual result_void start() { return result_void{}; }
+    virtual result_void start() { return common::ok(); }
 
     /**
      * @brief Stop the exporter
      */
-    virtual result_void stop() { return result_void{}; }
+    virtual result_void stop() { return common::ok(); }
 };
 
 /**
@@ -383,7 +383,7 @@ public:
             }
             
             exported_metrics_ += metrics.size();
-            return result_void{};
+            return common::ok();
 
         } catch (const std::exception& e) {
             failed_exports_++;
@@ -400,7 +400,7 @@ public:
                                   prom_metrics.begin(), prom_metrics.end());
             
             exported_metrics_++;
-            return result_void{};
+            return common::ok();
 
         } catch (const std::exception& e) {
             failed_exports_++;
@@ -428,7 +428,7 @@ public:
     
     result_void flush() override {
         // Prometheus is pull-based, so flush is a no-op
-        return result_void{};
+        return common::ok();
     }
     
     result_void shutdown() override {
@@ -605,7 +605,7 @@ public:
                 return send_result;
             }
 
-            return result_void{};
+            return common::ok();
 
         } catch (const std::exception& e) {
             failed_exports_++;
@@ -634,7 +634,7 @@ public:
                 return send_result;
             }
 
-            return result_void{};
+            return common::ok();
 
         } catch (const std::exception& e) {
             failed_exports_++;
@@ -645,7 +645,7 @@ public:
     
     result_void flush() override {
         // StatsD is push-based and sends immediately, so flush is a no-op
-        return result_void{};
+        return common::ok();
     }
     
     result_void shutdown() override {
@@ -665,7 +665,7 @@ private:
         // Simulate UDP sending
         // In real implementation, this would create UDP socket and send packets
         (void)lines; // Suppress unused parameter warning
-        return result_void{};
+        return common::ok();
     }
     
     std::string sanitize_metric_name(const std::string& name) const {
@@ -731,7 +731,7 @@ public:
             }
             
             exported_metrics_ += metrics.size();
-            return result_void{};
+            return common::ok();
 
         } catch (const std::exception& e) {
             failed_exports_++;
@@ -760,7 +760,7 @@ public:
             }
             
             exported_metrics_++;
-            return result_void{};
+            return common::ok();
 
         } catch (const std::exception& e) {
             failed_exports_++;
@@ -771,7 +771,7 @@ public:
     
     result_void flush() override {
         // OTLP exporter typically sends immediately, so flush is a no-op
-        return result_void{};
+        return common::ok();
     }
     
     result_void shutdown() override {
@@ -790,7 +790,7 @@ private:
         // Simulate OTLP sending based on format
         // In real implementation, this would use OTLP client
         (void)metrics; // Suppress unused parameter warning
-        return result_void{};
+        return common::ok();
     }
 };
 

--- a/include/kcenon/monitoring/exporters/opentelemetry_adapter.h
+++ b/include/kcenon/monitoring/exporters/opentelemetry_adapter.h
@@ -370,7 +370,7 @@ struct opentelemetry_exporter_config {
             return result_void::err(error_info(monitoring_error_code::invalid_configuration,
                                     "Batch size must be positive", "monitoring_system").to_common_error());
         }
-        return result_void{};
+        return common::ok();
     }
 };
 
@@ -396,7 +396,7 @@ public:
         }
 
         initialized_ = true;
-        return result_void{};
+        return common::ok();
     }
     
     /**
@@ -405,7 +405,7 @@ public:
     result_void shutdown() {
         std::lock_guard<std::mutex> lock(mutex_);
         if (!initialized_) {
-            return result_void{};
+            return common::ok();
         }
         
         // Flush any pending data without re-locking
@@ -414,7 +414,7 @@ public:
         pending_metrics_.clear();
         
         initialized_ = false;
-        return result_void{};
+        return common::ok();
     }
     
     /**
@@ -437,7 +437,7 @@ public:
         const auto& otel_spans = convert_result.value();
         pending_spans_.insert(pending_spans_.end(), otel_spans.begin(), otel_spans.end());
 
-        return result_void{};
+        return common::ok();
     }
     
     /**
@@ -460,7 +460,7 @@ public:
         const auto& otel_metrics = convert_result.value();
         pending_metrics_.insert(pending_metrics_.end(), otel_metrics.begin(), otel_metrics.end());
 
-        return result_void{};
+        return common::ok();
     }
     
     /**
@@ -474,7 +474,7 @@ public:
         pending_spans_.clear();
         pending_metrics_.clear();
         
-        return result_void{};
+        return common::ok();
     }
     
     /**

--- a/include/kcenon/monitoring/exporters/trace_exporters.h
+++ b/include/kcenon/monitoring/exporters/trace_exporters.h
@@ -89,7 +89,7 @@ struct trace_export_config {
                              "Queue size must be at least batch size", "monitoring_system").to_common_error());
         }
 
-        return result_void{};
+        return common::ok();
     }
 };
 
@@ -247,7 +247,7 @@ public:
                 return send_result;
             }
 
-            return result_void{};
+            return common::ok();
 
         } catch (const std::exception& e) {
             failed_exports_++;
@@ -258,7 +258,7 @@ public:
     
     result_void flush() override {
         // Jaeger exporter typically sends immediately, so flush is a no-op
-        return result_void{};
+        return common::ok();
     }
     
     result_void shutdown() override {
@@ -278,14 +278,14 @@ private:
         // Simulate Thrift protocol sending
         // In real implementation, this would serialize to Thrift and send via HTTP/UDP
         (void)spans; // Suppress unused parameter warning
-        return result_void{};
+        return common::ok();
     }
 
     result_void send_grpc_batch(const std::vector<jaeger_span_data>& spans) {
         // Simulate gRPC protocol sending
         // In real implementation, this would use Jaeger gRPC client
         (void)spans; // Suppress unused parameter warning
-        return result_void{};
+        return common::ok();
     }
 };
 
@@ -367,7 +367,7 @@ public:
                 return send_result;
             }
 
-            return result_void{};
+            return common::ok();
 
         } catch (const std::exception& e) {
             failed_exports_++;
@@ -378,7 +378,7 @@ public:
     
     result_void flush() override {
         // Zipkin exporter typically sends immediately, so flush is a no-op
-        return result_void{};
+        return common::ok();
     }
     
     result_void shutdown() override {
@@ -398,14 +398,14 @@ private:
         // Simulate JSON format sending via HTTP
         // In real implementation, this would serialize to JSON and POST to Zipkin
         (void)spans; // Suppress unused parameter warning
-        return result_void{};
+        return common::ok();
     }
     
     result_void send_protobuf_batch(const std::vector<zipkin_span_data>& spans) {
         // Simulate Protocol Buffers format sending
         // In real implementation, this would serialize to protobuf and send via HTTP
         (void)spans; // Suppress unused parameter warning
-        return result_void{};
+        return common::ok();
     }
 };
 
@@ -457,7 +457,7 @@ public:
                 return send_result;
             }
 
-            return result_void{};
+            return common::ok();
 
         } catch (const std::exception& e) {
             failed_exports_++;
@@ -468,7 +468,7 @@ public:
     
     result_void flush() override {
         // OTLP exporter typically sends immediately, so flush is a no-op
-        return result_void{};
+        return common::ok();
     }
     
     result_void shutdown() override {
@@ -488,21 +488,21 @@ private:
         // Simulate OTLP gRPC sending
         // In real implementation, this would use OTLP gRPC client
         (void)spans; // Suppress unused parameter warning
-        return result_void{};
+        return common::ok();
     }
     
     result_void send_http_json_batch(const std::vector<otel_span_data>& spans) {
         // Simulate OTLP HTTP JSON sending
         // In real implementation, this would serialize OTEL spans to JSON and POST
         (void)spans; // Suppress unused parameter warning
-        return result_void{};
+        return common::ok();
     }
     
     result_void send_http_protobuf_batch(const std::vector<otel_span_data>& spans) {
         // Simulate OTLP HTTP protobuf sending
         // In real implementation, this would serialize OTEL spans to protobuf and POST
         (void)spans; // Suppress unused parameter warning
-        return result_void{};
+        return common::ok();
     }
 };
 

--- a/tests/test_data_consistency.cpp
+++ b/tests/test_data_consistency.cpp
@@ -55,7 +55,7 @@ protected:
     result_void test_operation() {
         ++call_count;
         ++success_count;
-        return result_void{};
+        return common::ok();
     }
     
     // Helper function that fails
@@ -67,7 +67,7 @@ protected:
     // Helper function for rollback
     result_void rollback_operation() {
         ++rollback_count;
-        return result_void{};
+        return common::ok();
     }
     
     // Helper validation function
@@ -80,7 +80,7 @@ protected:
     }
     
     result_void test_repair() {
-        return result_void{};
+        return common::ok();
     }
 };
 
@@ -236,7 +236,7 @@ TEST_F(DataConsistencyTest, StateValidatorFailureAndRepair) {
         },
         [&should_fail]() { 
             should_fail = false; // Repair fixes the issue
-            return result_void{}; 
+            return common::ok(); 
         }
     );
     


### PR DESCRIPTION
## Summary

Replace all instances of `result_void{}` with `common::ok()` to improve code consistency and readability across the exporters and test code.

## Changes

- **metric_exporters.h**: Updated all success return statements in metric exporter classes
- **opentelemetry_adapter.h**: Updated all success return statements in OpenTelemetry adapter  
- **trace_exporters.h**: Updated all success return statements in trace exporter classes
- **test_data_consistency.cpp**: Updated test helper functions

## Motivation

The `common::ok()` function is more explicit about indicating a successful operation compared to the default constructor `result_void{}`. This change:

1. **Improves readability**: Makes it clearer that a function is returning a success result
2. **Consistency**: Aligns with the project's error handling patterns
3. **Maintainability**: Makes the codebase easier to understand for new contributors

## Testing

- Existing unit tests continue to pass
- No functional changes, only syntactic improvements

## Checklist

- [x] Code follows project style guidelines
- [x] All modified files are included
- [x] Commit message follows conventional commits format
- [x] No breaking changes introduced