### PR TITLE
fix: add deprecation warning to circuit_breaker stub implementation

### DIFF
--- a/include/kcenon/monitoring/reliability/circuit_breaker.h
+++ b/include/kcenon/monitoring/reliability/circuit_breaker.h
@@ -70,7 +70,7 @@ struct circuit_breaker_metrics {
  * @brief Basic circuit breaker implementation - stub
  */
 template<typename T = void>
-class circuit_breaker {
+class [[deprecated("STUB implementation. Do not use in production. See KNOWN_ISSUES.md.")]] circuit_breaker {
 public:
     using config = circuit_breaker_config;
 


### PR DESCRIPTION
## Summary
Mark the circuit_breaker class template as deprecated to prevent accidental usage.

## Problem
The `circuit_breaker` class in `reliability/circuit_breaker.h` is currently a stub 
implementation that does not provide actual circuit breaker functionality. Users 
may unknowingly depend on this incomplete implementation.

## Solution
Add `[[deprecated]]` attribute with a clear message:
```cpp
class [[deprecated("STUB implementation. Do not use in production. See KNOWN_ISSUES.md.")]] circuit_breaker
```

This generates compiler warnings when the class is used, alerting developers to 
the stub nature of the implementation.

## Test plan
- [x] Build verification passes
- [x] Deprecation warning appears when circuit_breaker is instantiated