### PR TITLE
feat(monitoring): add thread safety verification for Monitor classes

### DIFF
--- a/docs/advanced/ARCHITECTURE_ISSUES.md
+++ b/docs/advanced/ARCHITECTURE_ISSUES.md
@@ -193,7 +193,7 @@ This document catalogs known architectural issues in monitoring_system identifie
 - [ ] Document baseline metrics
 
 ### Phase 1 Actions
-- [ ] Resolve ARC-003 (Monitor thread safety)
+- [x] Resolve ARC-003 (Monitor thread safety) - 2025-11-26
 
 ### Phase 2 Actions
 - [ ] Resolve ARC-002 (Performance benchmarks)


### PR DESCRIPTION
## Summary

- Fix data race in `performance_profiler::use_lock_free_path_` by using `std::atomic<bool>`
- Add mutex protection for `performance_monitor::thresholds_` with `get_thresholds()` accessor
- Add mutex protection for `adaptive_collector::config_` to prevent concurrent access
- Refactor `adaptive_collector::adapt()` to copy config before acquiring `stats_mutex_` to avoid deadlock
- Add comprehensive thread safety documentation to class headers

## Test plan

- [x] All 82 existing tests pass
- [x] 5 new thread safety tests added and passing
- [x] ThreadSanitizer enabled build passes without data race warnings
- [x] 12 thread safety tests pass with TSan

## Related

Closes MON-ARC-003