### PR TITLE
feat(tests): Enable test_adaptive_monitoring.cpp for MON-002

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ if(EXISTS ${MONITORING_INCLUDE_DIR}/kcenon/monitoring AND EXISTS ${MONITORING_SO
         target_include_directories(monitoring_system
             PUBLIC
                 $<BUILD_INTERFACE:${MONITORING_INCLUDE_DIR}>
-                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/sources>
+                $<BUILD_INTERFACE:${MONITORING_SOURCE_DIR}>
                 $<INSTALL_INTERFACE:include>
         )
     else()
@@ -243,7 +243,7 @@ if(EXISTS ${MONITORING_INCLUDE_DIR}/kcenon/monitoring AND EXISTS ${MONITORING_SO
 
         target_include_directories(monitoring_system
             PUBLIC
-                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/sources>
+                $<BUILD_INTERFACE:${MONITORING_SOURCE_DIR}>
                 $<BUILD_INTERFACE:${MONITORING_INCLUDE_DIR}>
                 $<INSTALL_INTERFACE:include>
         )
@@ -264,7 +264,8 @@ else()
 
     target_include_directories(monitoring_system
         PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/sources>
+            $<BUILD_INTERFACE:${MONITORING_SOURCE_DIR}>
+            $<BUILD_INTERFACE:${MONITORING_INCLUDE_DIR}>
             $<INSTALL_INTERFACE:include>
     )
 endif()

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -67,17 +67,29 @@ All platforms have complete implementations for:
 
 | Category | Active | Total | Notes |
 |----------|--------|-------|-------|
-| Unit Tests | 5 | 23 | 18 tests disabled |
+| Unit Tests | 11 | 24 | 13 tests disabled |
 | Thread Safety Tests | 1 | 1 | - |
 | Integration Tests | - | - | Framework only |
+
+### Active Tests
+
+The following test files are enabled and passing:
+- `test_result_types.cpp`
+- `test_di_container.cpp`
+- `test_monitorable_interface.cpp`
+- `test_thread_context_simple.cpp`
+- `test_lock_free_collector.cpp`
+- `test_distributed_tracing.cpp`
+- `test_performance_monitoring.cpp`
+- `test_event_bus.cpp`
+- `test_trace_exporters.cpp`
+- `test_adapter_functionality.cpp`
+- `test_adaptive_monitoring.cpp` (124 tests total)
 
 ### Disabled Tests
 
 The following test files are commented out in `tests/CMakeLists.txt`:
 
-- `test_distributed_tracing.cpp`
-- `test_performance_monitoring.cpp`
-- `test_adaptive_monitoring.cpp`
 - `test_health_monitoring.cpp`
 - `test_metric_storage.cpp`
 - `test_stream_aggregation.cpp`
@@ -88,11 +100,9 @@ The following test files are commented out in `tests/CMakeLists.txt`:
 - `test_resource_management.cpp`
 - `test_data_consistency.cpp`
 - `test_opentelemetry_adapter.cpp`
-- `test_trace_exporters.cpp`
 - `test_metric_exporters.cpp`
 - `test_storage_backends.cpp`
 - `test_integration_e2e.cpp`
-- `test_stress_performance.cpp`
 
 **Reason:** API alignment and missing implementations. See MON-002.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,8 +37,10 @@ add_executable(monitoring_system_tests
     test_trace_exporters.cpp
     test_adapter_functionality.cpp
 
+    test_adaptive_monitoring.cpp
+
     # =========================================================================
-    # MON-002: Deferred tests requiring API updates or missing headers (14 remaining)
+    # MON-002: Deferred tests requiring API updates or missing headers (13 remaining)
     # =========================================================================
     # The following tests require significant updates due to:
     # - Result<T> API changes (need .is_ok() instead of bool conversion)
@@ -47,7 +49,6 @@ add_executable(monitoring_system_tests
     #
     # test_metric_exporters.cpp       # monitoring_data type missing
     # test_opentelemetry_adapter.cpp  # monitoring_data type missing, Result API
-    # test_adaptive_monitoring.cpp    # Result<T> API updates needed
     # test_health_monitoring.cpp      # Result<T> API updates needed
     # test_fault_tolerance.cpp        # Result<T> API updates needed
     # test_error_boundaries.cpp       # Missing: graceful_degradation.h

--- a/tests/test_adaptive_monitoring.cpp
+++ b/tests/test_adaptive_monitoring.cpp
@@ -36,8 +36,9 @@
 #include <thread>
 #include <chrono>
 #include <memory>
-// Note: adaptive_monitor.h does not exist in include directory
-// #include <kcenon/monitoring/adaptive/adaptive_monitor.h>
+// Include impl headers directly (src directory is in include path via monitoring_system target)
+#include "impl/adaptive_monitor.h"
+#include <kcenon/monitoring/core/performance_monitor.h>
 
 using namespace kcenon::monitoring;
 
@@ -276,15 +277,15 @@ TEST_F(AdaptiveMonitoringTest, AdaptiveScope) {
         adaptive_scope scope("scoped", mock);
         EXPECT_TRUE(scope.is_registered());
         
-        // Collector should be registered  
+        // Collector should be registered
         // Use the monitor member instead of global monitor
         auto stats = global_adaptive_monitor().get_collector_stats("scoped");
-        EXPECT_TRUE(stats.has_value());
+        EXPECT_TRUE(stats.is_ok());
     }
     // Scope destroyed, collector should be unregistered
-    
+
     auto stats = global_adaptive_monitor().get_collector_stats("scoped");
-    EXPECT_FALSE(stats.has_value());
+    EXPECT_FALSE(stats.is_ok());
 }
 
 TEST_F(AdaptiveMonitoringTest, MemoryPressureAdaptation) {
@@ -350,8 +351,8 @@ TEST_F(AdaptiveMonitoringTest, AdaptationInterval) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1500));
     
     auto stats = monitor.get_collector_stats("test");
-    ASSERT_TRUE(stats.has_value());
-    
+    ASSERT_TRUE(stats.is_ok());
+
     // Should have adapted at least once
     EXPECT_GE(stats.value().total_adaptations, 0);
 }


### PR DESCRIPTION
## Summary
- Enable adaptive monitoring tests (17 new tests, 124 total passing)
- Fix Result API usage: `has_value()` -> `is_ok()`
- Fix CMakeLists.txt include path: `sources` -> `src` (MONITORING_SOURCE_DIR)
- Update KNOWN_ISSUES.md with current test status

## Changes
- **tests/test_adaptive_monitoring.cpp**: Fixed Result API calls and enabled header includes
- **tests/CMakeLists.txt**: Added test_adaptive_monitoring.cpp to build (13 disabled tests remaining)
- **CMakeLists.txt**: Fixed include directory path bug (sources -> MONITORING_SOURCE_DIR)
- **docs/KNOWN_ISSUES.md**: Updated test coverage section with current status

## Test Plan
- [x] All 124 tests pass
- [x] All 17 AdaptiveMonitoring tests pass
- [x] Build succeeds on macOS

## Related
- Ticket: MON-002 (API Alignment)
- Progress: 14 disabled -> 13 disabled