### PR TITLE
docs: verify common_system v3.0.0 compatibility

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `/w14996` for MSVC compiler
   - Catches usage of deprecated common_system APIs before v3.0.0 removal
   - No deprecated API usage found in codebase (already using new patterns)
+- **common_system v3.0.0 compatibility verification** (#269)
+  - Verified no usage of deprecated `THREAD_LOG_*` macros (already using `LOG_*` macros)
+  - Verified no usage of legacy `log(level, msg, file, line, func)` method
+  - Codebase already uses modern `log(level, msg)` with automatic source_location
+  - Ready for common_system v3.0.0 upgrade with no code changes required
 
 ### Changed
 - **thread_system v3.0 compatibility** (#263)

--- a/docs/CHANGELOG_KO.md
+++ b/docs/CHANGELOG_KO.md
@@ -63,6 +63,11 @@ Monitoring System의 모든 주목할 만한 변경 사항이 이 파일에 문�
   - MSVC 컴파일러용 `/w14996` 추가
   - common_system v3.0.0 제거 전에 deprecated API 사용 감지
   - 코드베이스에서 deprecated API 사용 없음 (이미 새로운 패턴 사용 중)
+- **common_system v3.0.0 호환성 확인** (#269)
+  - deprecated `THREAD_LOG_*` 매크로 사용하지 않음 확인 (이미 `LOG_*` 매크로 사용 중)
+  - legacy `log(level, msg, file, line, func)` 메서드 사용하지 않음 확인
+  - 코드베이스가 이미 자동 source_location을 사용하는 modern `log(level, msg)` 사용 중
+  - common_system v3.0.0 업그레이드 시 코드 변경 불필요
 
 ### 수정됨
 - **FetchContent를 통해 monitoring_system 사용 시 CMake 오류 수정** (#261)


### PR DESCRIPTION
## Summary

- Verified that monitoring_system is already compatible with common_system v3.0.0
- No deprecated API usage found in codebase
- Updated CHANGELOG documentation to reflect compatibility status

## Changes

- Searched for deprecated `THREAD_LOG_*` macros - **not used** (already using `LOG_*` macros)
- Searched for legacy `log(level, msg, file, line, func)` method - **not used**
- Build completed with no common_system deprecation warnings
- All 464/466 tests passing (2 failures unrelated to this change)

## Verification Results

| Deprecated API | Status |
|----------------|--------|
| `THREAD_LOG_*` macros | Not used ✅ |
| Legacy `log()` with 5 params | Not used ✅ |
| Build deprecation warnings | None ✅ |

## Test plan

- [x] Search codebase for deprecated APIs
- [x] Build project and check for deprecation warnings
- [x] Run test suite to verify no regressions
- [x] Update CHANGELOG documentation

Closes #269