### PR TITLE
refactor(buffer): consolidate load_average_history with time_series_buffer

### DIFF
--- a/include/kcenon/monitoring/utils/time_series_buffer.h
+++ b/include/kcenon/monitoring/utils/time_series_buffer.h
@@ -404,7 +404,7 @@ class time_series_buffer {
     result<T> get_latest() const {
         auto sample_result = buffer_.get_latest();
         if (sample_result.is_err()) {
-            return make_error<T>(sample_result.error().code, sample_result.error().message);
+            return common::Result<T>::err(sample_result.error());
         }
         return make_success(sample_result.value().value);
     }


### PR DESCRIPTION
## Summary

Extract common ring buffer logic into `detail::time_series_ring_buffer<Sample>` template class to eliminate ~90% code duplication between `time_series_buffer<T>` and `load_average_history`.

## Changes

- Add `time_series_ring_buffer<Sample>` as internal base implementation in `detail` namespace
- Refactor `time_series_buffer<T>` to use the new base class
- Refactor `load_average_history` to use the new base class
- Add missing `<stdexcept>` header include

## Benefits

- **No Duplication**: Single ring buffer implementation for time-series data
- **Maintainability**: Bug fixes only need to be applied once
- **No Breaking Changes**: Public API remains unchanged

## Test Plan

- [x] All 26 TimeSeriesBuffer and LoadAverageHistory tests pass
- [x] Thread safety tests pass
- [x] Statistics calculation tests pass
- [x] Full test suite passes (462/464, 2 pre-existing hardware-related failures)

Closes #311