### PR TITLE
feat(tracing): Connect distributed_tracer to trace exporters (ARC-006)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Connect distributed_tracer to trace exporters (ARC-006)** (#321)
+  - Connected `distributed_tracer` to `trace_exporter_interface` for Jaeger/Zipkin/OTLP export
+  - Added `set_exporter()` method to configure trace exporters
+  - Added `configure_export()` for export settings (batch_size, max_queue_size, export_on_finish)
+  - Implemented automatic batch export when buffer threshold is reached
+  - Added `flush()` method for manual span export
+  - Export failure handling with retry/queue mechanism
+  - Export statistics: `get_export_stats()` returns exported_spans, failed_exports, dropped_spans
+  - Queue size limit enforcement to prevent memory exhaustion
+  - Comprehensive unit tests for exporter integration
 - **Windows CPU/Memory stats collection in system_resource_collector** (#319)
   - Implemented `collect_windows_cpu_stats()` using `GetSystemTimes()` API
   - Implemented `collect_windows_memory_stats()` using `GlobalMemoryStatusEx()` API

--- a/docs/CHANGELOG_KO.md
+++ b/docs/CHANGELOG_KO.md
@@ -57,6 +57,16 @@ Monitoring System의 모든 주목할 만한 변경 사항이 이 파일에 문�
 ## [Unreleased]
 
 ### 추가됨
+- **distributed_tracer를 trace exporter에 연결 (ARC-006)** (#321)
+  - `distributed_tracer`를 `trace_exporter_interface`에 연결하여 Jaeger/Zipkin/OTLP export 지원
+  - trace exporter 설정을 위한 `set_exporter()` 메서드 추가
+  - export 설정을 위한 `configure_export()` 추가 (batch_size, max_queue_size, export_on_finish)
+  - 버퍼 임계값 도달 시 자동 배치 export 구현
+  - 수동 span export를 위한 `flush()` 메서드 추가
+  - retry/queue 메커니즘을 통한 export 실패 처리
+  - export 통계: `get_export_stats()`가 exported_spans, failed_exports, dropped_spans 반환
+  - 메모리 고갈 방지를 위한 큐 크기 제한 적용
+  - exporter 통합을 위한 종합 유닛 테스트
 - **system_resource_collector에서 Windows CPU/메모리 통계 수집** (#319)
   - `GetSystemTimes()` API를 사용하여 `collect_windows_cpu_stats()` 구현
   - `GlobalMemoryStatusEx()` API를 사용하여 `collect_windows_memory_stats()` 구현

--- a/docs/advanced/ARCHITECTURE_ISSUES.md
+++ b/docs/advanced/ARCHITECTURE_ISSUES.md
@@ -145,16 +145,25 @@ This document catalogs known architectural issues in monitoring_system identifie
 
 ### 4. Features & Functionality
 
-#### Issue ARC-006: Distributed Tracing Incomplete
+#### ~~Issue ARC-006: Distributed Tracing Incomplete~~ ✅ RESOLVED
 - **Priority**: P1 (Medium)
 - **Phase**: Phase 4
+- **Status**: ✅ **RESOLVED** (2026-01-08)
 - **Description**: Distributed tracing implementation needs completion
 - **Impact**: Limited observability in distributed systems
-- **Investigation Required**:
-  - Complete trace context propagation
-  - Implement trace aggregation
-  - Add distributed trace visualization
-- **Acceptance Criteria**: Full distributed tracing support
+- **Resolution**:
+  - ✅ Connected `distributed_tracer` to `trace_exporter_interface`
+  - ✅ Implemented `set_exporter()` method for configuring exporters (Jaeger, Zipkin, OTLP)
+  - ✅ Added automatic batch export when buffer threshold is reached
+  - ✅ Implemented manual `flush()` for immediate export
+  - ✅ Added export settings configuration (batch_size, max_queue_size, export_on_finish)
+  - ✅ Implemented export failure handling with retry/queue mechanism
+  - ✅ Added export statistics tracking (exported_spans, failed_exports, dropped_spans)
+  - ✅ Comprehensive unit tests for exporter integration
+- **References**:
+  - Implementation: `src/impl/tracing/distributed_tracer.cpp`
+  - Header: `src/impl/tracing/distributed_tracer.h`
+  - Tests: `tests/test_distributed_tracing.cpp` (ExporterIntegrationTest)
 
 #### ~~Issue ARC-007: Limited Metric Types~~ ✅ RESOLVED
 - **Priority**: P2 (Low)
@@ -254,7 +263,7 @@ This document catalogs known architectural issues in monitoring_system identifie
 - [x] Resolve ARC-010 (Common system integration) - 2025-11-27
 
 ### Phase 4 Actions
-- [ ] Resolve ARC-006 (Distributed tracing)
+- [x] Resolve ARC-006 (Distributed tracing) - 2026-01-08
 - [x] Resolve ARC-007 (Metric types) - 2025-11-27
 
 ### Phase 5 Actions
@@ -296,4 +305,4 @@ This document catalogs known architectural issues in monitoring_system identifie
 
 ---
 
-*Last Updated: 2025-11-27 (ARC-009 Resolved)*
+*Last Updated: 2026-01-08 (ARC-006 Resolved)*

--- a/src/impl/tracing/distributed_tracer.h
+++ b/src/impl/tracing/distributed_tracer.h
@@ -53,6 +53,20 @@
 
 namespace kcenon { namespace monitoring {
 
+// Forward declaration for trace exporter interface
+class trace_exporter_interface;
+
+/**
+ * @struct trace_export_settings
+ * @brief Configuration settings for trace export behavior
+ */
+struct trace_export_settings {
+    std::size_t batch_size = 100;           ///< Number of spans to batch before export
+    std::chrono::milliseconds flush_interval{5000};  ///< Interval for automatic flush
+    std::size_t max_queue_size = 2048;      ///< Maximum spans in queue before dropping
+    bool export_on_finish = true;           ///< Export when batch is full
+};
+
 /**
  * @brief Trace span representing a unit of work in distributed tracing
  */
@@ -318,6 +332,42 @@ public:
      * @brief Export spans to external system
      */
     kcenon::monitoring::result<bool> export_spans(std::vector<trace_span> spans);
+
+    /**
+     * @brief Set the trace exporter for span export
+     * @param exporter Shared pointer to trace exporter implementation
+     */
+    void set_exporter(std::shared_ptr<trace_exporter_interface> exporter);
+
+    /**
+     * @brief Get the current trace exporter
+     * @return Shared pointer to current exporter, or nullptr if not set
+     */
+    std::shared_ptr<trace_exporter_interface> get_exporter() const;
+
+    /**
+     * @brief Configure export settings
+     * @param settings Export configuration settings
+     */
+    void configure_export(const trace_export_settings& settings);
+
+    /**
+     * @brief Get current export settings
+     * @return Current export settings
+     */
+    trace_export_settings get_export_settings() const;
+
+    /**
+     * @brief Manually flush all pending spans to exporter
+     * @return Result indicating success or failure
+     */
+    result_void flush();
+
+    /**
+     * @brief Get export statistics
+     * @return Map of statistic name to value
+     */
+    std::unordered_map<std::string, std::size_t> get_export_stats() const;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Connect `distributed_tracer` to `trace_exporter_interface` for Jaeger/Zipkin/OTLP export
- Implement automatic batch export and manual flush capabilities
- Add export configuration and statistics tracking
- Resolve ARC-006 (Distributed Tracing Incomplete)

## Changes
- Add `set_exporter()` method for configuring trace exporters
- Add `configure_export()` for export settings (batch_size, max_queue_size, export_on_finish)
- Implement automatic batch export when buffer threshold is reached
- Add `flush()` method for manual span export
- Implement export failure handling with retry/queue mechanism
- Add `get_export_stats()` for export statistics tracking
- Enforce queue size limit to prevent memory exhaustion
- Add `trace_export_settings` struct for configuration

## Test plan
- [x] Added comprehensive unit tests for exporter integration (ExporterIntegrationTest)
- [x] Tests cover: set/get exporter, configure settings, auto export, manual flush, failure handling, stats, queue limits
- [x] Build verified on macOS

## Documentation
- [x] Updated ARCHITECTURE_ISSUES.md to mark ARC-006 as resolved
- [x] Updated CHANGELOG.md and CHANGELOG_KO.md with feature details

Closes #321