### PR TITLE
fix(tests): enable metric exporters and opentelemetry adapter tests (ARC-001 Phase 1)

### DIFF
--- a/include/kcenon/monitoring/exporters/udp_transport.h
+++ b/include/kcenon/monitoring/exporters/udp_transport.h
@@ -139,6 +139,9 @@ private:
 public:
     stub_udp_transport() = default;
 
+    // Bring base class send method into scope
+    using udp_transport::send;
+
     /**
      * @brief Set whether to simulate success or failure
      */
@@ -221,25 +224,29 @@ public:
     uint16_t get_port() const { return port_; }
 };
 
+} } // namespace kcenon::monitoring
+
 #ifdef MONITORING_HAS_COMMON_TRANSPORT_INTERFACES
 #include <kcenon/common/interfaces/transport.h>
+
+namespace kcenon { namespace monitoring {
 
 /**
  * @class common_udp_transport
  * @brief UDP transport implementation using common_system interfaces
  *
  * This implementation provides real UDP functionality by delegating
- * to common::interfaces::IUdpClient implementations.
+ * to ::kcenon::common::interfaces::IUdpClient implementations.
  */
 class common_udp_transport : public udp_transport {
 private:
-    std::shared_ptr<common::interfaces::IUdpClient> client_;
+    std::shared_ptr<::kcenon::common::interfaces::IUdpClient> client_;
     mutable std::atomic<std::size_t> packets_sent_{0};
     mutable std::atomic<std::size_t> bytes_sent_{0};
     mutable std::atomic<std::size_t> send_failures_{0};
 
 public:
-    explicit common_udp_transport(std::shared_ptr<common::interfaces::IUdpClient> client)
+    explicit common_udp_transport(std::shared_ptr<::kcenon::common::interfaces::IUdpClient> client)
         : client_(std::move(client)) {}
 
     result_void connect(const std::string& host, uint16_t port) override {
@@ -332,10 +339,14 @@ public:
     }
 };
 
+} } // namespace kcenon::monitoring
+
 #endif // MONITORING_HAS_COMMON_TRANSPORT_INTERFACES
 
 #ifdef MONITORING_HAS_NETWORK_SYSTEM
 #include <kcenon/network/udp/udp_client.h>
+
+namespace kcenon { namespace monitoring {
 
 /**
  * @class network_udp_transport
@@ -441,7 +452,11 @@ public:
     }
 };
 
+} } // namespace kcenon::monitoring
+
 #endif // MONITORING_HAS_NETWORK_SYSTEM
+
+namespace kcenon { namespace monitoring {
 
 /**
  * @brief Create default UDP transport
@@ -471,7 +486,7 @@ inline std::unique_ptr<stub_udp_transport> create_stub_udp_transport() {
  * @param client The IUdpClient implementation to use
  */
 inline std::unique_ptr<common_udp_transport> create_common_udp_transport(
-    std::shared_ptr<common::interfaces::IUdpClient> client) {
+    std::shared_ptr<::kcenon::common::interfaces::IUdpClient> client) {
     return std::make_unique<common_udp_transport>(std::move(client));
 }
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,18 +94,24 @@ add_executable(monitoring_system_tests
     # Platform metrics provider (Issue #295)
     test_metrics_provider.cpp
 
+    # Metric exporters and OpenTelemetry adapter tests (Issue #320 - Phase 1)
+    test_metric_exporters.cpp
+    test_opentelemetry_adapter.cpp
+
     # =========================================================================
-    # MON-002: Deferred tests requiring API updates or missing headers (12 remaining)
+    # MON-002: Deferred tests requiring API updates or missing headers (10 remaining)
     # =========================================================================
     # The following tests require significant updates due to:
     # - Result<T> API changes (need .is_ok() instead of bool conversion)
     # - Missing header files (graceful_degradation.h, resource_manager.h, etc.)
-    # - Type mismatches (monitoring_data not in current API)
+    # - Missing API implementations (health_check base class, retry_executor, etc.)
     #
-    # test_metric_exporters.cpp       # monitoring_data type missing
-    # test_opentelemetry_adapter.cpp  # monitoring_data type missing, Result API
-    # test_health_monitoring.cpp      # Result<T> API updates needed
-    # test_fault_tolerance.cpp        # Result<T> API updates needed
+    # test_health_monitoring.cpp      # Requires: health_check base class, composite_health_check,
+    #                                 #           health_dependency_graph, health_check_builder,
+    #                                 #           global_health_monitor() - See Issue #320-1
+    # test_fault_tolerance.cpp        # Requires: retry_executor<T>, fault_tolerance_config,
+    #                                 #           circuit breaker registries, config validation
+    #                                 #           - See Issue #320-2
     # test_error_boundaries.cpp       # Missing: graceful_degradation.h
     # test_optimization.cpp           # Missing: optimization/ folder
     # test_resource_management.cpp    # Missing: resource_manager.h


### PR DESCRIPTION
## Summary
- Enable 2 of 4 disabled tests from ARC-001 Phase 1
- Fix Result<T> API usage patterns in test files
- Fix namespace issues in udp_transport.h

## Changes

### test_opentelemetry_adapter.cpp
- Replace `EXPECT_TRUE(result)` with `EXPECT_TRUE(result.is_ok())`
- Replace `EXPECT_FALSE(result)` with `EXPECT_TRUE(result.is_err())`
- Fix error code comparisons to use `static_cast<int>()`
- Fix `ASSERT_TRUE` calls on Result types

### include/kcenon/monitoring/exporters/udp_transport.h
- Close namespace before `#include` directives for common_system headers
- Add `using udp_transport::send` to expose base class convenience methods
- Restructure namespace blocks to avoid including external headers inside namespace scope

### tests/CMakeLists.txt
- Enable `test_metric_exporters.cpp` (39 tests)
- Enable `test_opentelemetry_adapter.cpp` (16 tests)
- Update comments for remaining disabled tests with required APIs

## Test Results
All 55 newly enabled tests pass:
- MetricExportersTest: 19 tests
- UdpTransportTest: 4 tests
- OpenTelemetryAdapterTest: 16 tests

## Remaining Work
The following tests remain disabled and require API implementation:
- `test_health_monitoring.cpp` - See #330
- `test_fault_tolerance.cpp` - See #329

## Dependencies
- Requires kcenon/common_system#273 to be merged first (namespace fixes)

## Resolves
Partial completion of #320