### PR TITLE
refactor(metrics): remove deprecated statistics methods from performance_metrics

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Removed
+- **Deprecated statistics methods from performance_metrics** (#385)
+  - Removed `performance_metrics::calculate_percentile()` - use `stats::percentile()` directly
+  - Removed `performance_metrics::update_statistics()` - use `stats::compute()` directly
+  - Removed `make_time_series()` helper functions - use `time_series::create()` instead
+  - Moved `statistics.h` include from header to implementation file for better encapsulation
 - **Deprecated Result type aliases and helper functions** (#383)
   - Removed `result<T>` type alias - use `common::Result<T>` directly
   - Removed `result_void` type alias - use `common::VoidResult` directly
@@ -68,7 +73,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed `make_error_with_context()` - use `error_info` with context parameter
   - Removed `MONITORING_TRY` macro - use `COMMON_RETURN_IF_ERROR` instead
   - Removed `MONITORING_TRY_ASSIGN` macro - use `COMMON_ASSIGN_OR_RETURN` instead
-  - Removed `make_time_series()` helper functions - use `time_series::create()` instead
   - All usages migrated to `common::Result<T>` and `common::VoidResult` from common_system
 
 ### Added

--- a/include/kcenon/monitoring/core/performance_monitor.h
+++ b/include/kcenon/monitoring/core/performance_monitor.h
@@ -56,7 +56,6 @@
 #include "../core/result_types.h"
 #include "../core/error_codes.h"
 #include "../interfaces/monitoring_core.h"
-#include "../utils/statistics.h"
 
 // Use common_system interfaces (Phase 2.3.4)
 #include <kcenon/common/interfaces/monitoring_interface.h>
@@ -132,32 +131,6 @@ struct performance_metrics {
     std::uint64_t error_count{0};
     double throughput{0.0};  // Operations per second
     
-    /**
-     * @brief Calculate percentile from sorted durations
-     * @deprecated Use stats::percentile() directly for new code
-     */
-    static std::chrono::nanoseconds calculate_percentile(
-        const std::vector<std::chrono::nanoseconds>& sorted_durations,
-        double percentile_value) {
-        return stats::percentile(sorted_durations, percentile_value);
-    }
-
-    /**
-     * @brief Update statistics with new duration samples
-     * @deprecated Use stats::compute() directly for new code
-     */
-    void update_statistics(const std::vector<std::chrono::nanoseconds>& durations) {
-        if (durations.empty()) return;
-
-        auto computed = stats::compute(durations);
-        min_duration = computed.min;
-        max_duration = computed.max;
-        mean_duration = computed.mean;
-        median_duration = computed.median;
-        p95_duration = computed.p95;
-        p99_duration = computed.p99;
-        total_duration = computed.total;
-    }
 };
 
 /**

--- a/src/core/performance_monitor.cpp
+++ b/src/core/performance_monitor.cpp
@@ -33,6 +33,7 @@
  */
 
 #include <kcenon/monitoring/core/performance_monitor.h>
+#include <kcenon/monitoring/utils/statistics.h>
 #include <shared_mutex>
 #include <deque>
 #include <limits>

--- a/src/utils/time_series.h
+++ b/src/utils/time_series.h
@@ -482,21 +482,4 @@ public:
     }
 };
 
-/**
- * @brief Helper function to create a time series with default configuration
- * @deprecated Use time_series::create() instead
- */
-inline common::Result<std::unique_ptr<time_series>> make_time_series(const std::string& name) {
-    return time_series::create(name);
-}
-
-/**
- * @brief Helper function to create a time series with custom configuration
- * @deprecated Use time_series::create() instead
- */
-inline common::Result<std::unique_ptr<time_series>> make_time_series(const std::string& name,
-                                                    const time_series_config& config) {
-    return time_series::create(name, config);
-}
-
 } } // namespace kcenon::monitoring


### PR DESCRIPTION
Closes #385

## Summary
- Remove deprecated `performance_metrics::calculate_percentile()` method - use `stats::percentile()` directly
- Remove deprecated `performance_metrics::update_statistics()` method - use `stats::compute()` directly
- Remove deprecated `make_time_series()` factory functions - use `time_series::create()` directly
- Move `statistics.h` include from header to implementation for better encapsulation

## Migration Guide

### Statistics Calculation
```cpp
// Before
auto p95 = performance_metrics::calculate_percentile(durations, 0.95);
metrics.update_statistics(durations);

// After
#include <kcenon/monitoring/utils/statistics.h>
auto p95 = stats::percentile(durations, 0.95);
auto computed = stats::compute(durations);
// Use computed.min, computed.max, computed.mean, computed.median, computed.p95, computed.p99
```

### Time Series Creation
```cpp
// Before
auto ts = make_time_series(...);

// After
auto ts = time_series::create(...);
```

## Test Plan
- [x] Build passes on local machine
- [x] All performance monitoring tests pass (28 tests)
- [x] All statistics utility tests pass (21 tests)
- [x] All time series tests pass (18 tests)