### PR TITLE
refactor(utils): extract hot-path optimization pattern into reusable helper

### DIFF
--- a/include/kcenon/monitoring/utils/hot_path_helper.h
+++ b/include/kcenon/monitoring/utils/hot_path_helper.h
@@ -1,0 +1,242 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, monitoring_system contributors
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file hot_path_helper.h
+ * @brief Reusable hot-path optimization patterns for concurrent map access
+ * @date 2025
+ *
+ * Provides thread-safe get-or-create patterns using double-check locking
+ * with shared_mutex for optimal read performance on hot paths.
+ *
+ * The pattern reduces lock contention by:
+ * 1. First attempting read with shared_lock (allows concurrent readers)
+ * 2. Only acquiring exclusive write_lock when creation is necessary
+ * 3. Double-checking after write_lock to handle race conditions
+ */
+
+#pragma once
+
+#include <shared_mutex>
+
+namespace kcenon {
+namespace monitoring {
+namespace hot_path {
+
+/**
+ * @brief Get existing value or create new one using double-check locking
+ *
+ * This function implements the double-check locking pattern for thread-safe
+ * lazy initialization in concurrent maps. It optimizes for the common case
+ * where the key already exists (hot path) by using a shared lock first.
+ *
+ * @tparam Map Container type supporting find(), operator[], and emplace()
+ * @tparam Key Key type for the container
+ * @tparam CreateFn Callable returning the value to insert if key not found
+ *
+ * @param map The container to access
+ * @param mutex The shared_mutex protecting the container
+ * @param key The key to look up or create
+ * @param create_fn Factory function called when creating a new entry
+ *
+ * @return Pointer to the value (existing or newly created). Never null
+ *         unless create_fn fails. The pointer remains valid as long as
+ *         the entry exists in the map.
+ *
+ * @thread_safety Thread-safe. Uses shared_lock for reads, unique_lock for writes.
+ *
+ * @note The returned pointer should only be used while holding appropriate
+ *       locks or when the caller can guarantee the entry won't be removed.
+ *
+ * @example
+ * @code
+ * std::unordered_map<std::string, std::unique_ptr<Data>> data_map;
+ * std::shared_mutex map_mutex;
+ *
+ * // Get or create entry
+ * Data* data = hot_path::get_or_create(
+ *     data_map,
+ *     map_mutex,
+ *     "key1",
+ *     []() { return std::make_unique<Data>(); }
+ * );
+ *
+ * // data is now valid and can be used
+ * @endcode
+ */
+template <typename Map, typename Key, typename CreateFn>
+auto get_or_create(Map& map, std::shared_mutex& mutex, const Key& key,
+                   CreateFn create_fn) ->
+    typename std::remove_reference<decltype(*map.begin()->second)>::type* {
+    // Fast path: try with shared lock (read-only, allows concurrent readers)
+    {
+        std::shared_lock<std::shared_mutex> read_lock(mutex);
+        auto it = map.find(key);
+        if (it != map.end()) {
+            return it->second.get();
+        }
+    }
+
+    // Slow path: upgrade to write lock and double-check
+    {
+        std::unique_lock<std::shared_mutex> write_lock(mutex);
+        // Double-check after acquiring write lock
+        // Another thread may have created the entry while we were waiting
+        auto& ptr = map[key];
+        if (!ptr) {
+            ptr = create_fn();
+        }
+        return ptr.get();
+    }
+}
+
+/**
+ * @brief Get existing value or create new one with initialization callback
+ *
+ * Similar to get_or_create but additionally allows running an initialization
+ * function only when a new entry is created. Useful when the value needs
+ * additional setup beyond what the factory function provides.
+ *
+ * @tparam Map Container type supporting find(), operator[], and emplace()
+ * @tparam Key Key type for the container
+ * @tparam CreateFn Callable returning the value to insert if key not found
+ * @tparam InitFn Callable taking a reference to the value type for initialization
+ *
+ * @param map The container to access
+ * @param mutex The shared_mutex protecting the container
+ * @param key The key to look up or create
+ * @param create_fn Factory function called when creating a new entry
+ * @param init_fn Function called to initialize newly created entry (called under write lock)
+ *
+ * @return Pointer to the value (existing or newly created)
+ *
+ * @thread_safety Thread-safe. init_fn is called under write lock.
+ *
+ * @example
+ * @code
+ * std::unordered_map<std::string, std::unique_ptr<MetricData>> metrics;
+ * std::shared_mutex metrics_mutex;
+ *
+ * // Get or create with initialization
+ * auto* data = hot_path::get_or_create_with_init(
+ *     metrics,
+ *     metrics_mutex,
+ *     key,
+ *     []() { return std::make_unique<MetricData>(); },
+ *     [&](MetricData& d) {
+ *         d.type = metric_type;
+ *         d.tags = tags;
+ *     }
+ * );
+ * @endcode
+ */
+template <typename Map, typename Key, typename CreateFn, typename InitFn>
+auto get_or_create_with_init(Map& map, std::shared_mutex& mutex, const Key& key,
+                             CreateFn create_fn, InitFn init_fn) ->
+    typename std::remove_reference<decltype(*map.begin()->second)>::type* {
+    // Fast path: try with shared lock (read-only, allows concurrent readers)
+    {
+        std::shared_lock<std::shared_mutex> read_lock(mutex);
+        auto it = map.find(key);
+        if (it != map.end()) {
+            return it->second.get();
+        }
+    }
+
+    // Slow path: upgrade to write lock and double-check
+    {
+        std::unique_lock<std::shared_mutex> write_lock(mutex);
+        // Double-check after acquiring write lock
+        // Another thread may have created the entry while we were waiting
+        auto& ptr = map[key];
+        if (!ptr) {
+            ptr = create_fn();
+            // Initialize the newly created entry while still under write lock
+            init_fn(*ptr);
+        }
+        return ptr.get();
+    }
+}
+
+/**
+ * @brief Get existing value or create new one, then apply an update function
+ *
+ * Similar to get_or_create but additionally applies an update function to the
+ * value after retrieval. Useful when you need to both ensure the entry exists
+ * and perform an operation on it atomically with respect to creation.
+ *
+ * @tparam Map Container type supporting find(), operator[], and emplace()
+ * @tparam Key Key type for the container
+ * @tparam CreateFn Callable returning the value to insert if key not found
+ * @tparam UpdateFn Callable taking a reference to the value type
+ *
+ * @param map The container to access
+ * @param mutex The shared_mutex protecting the container
+ * @param key The key to look up or create
+ * @param create_fn Factory function called when creating a new entry
+ * @param update_fn Function applied to the value after retrieval
+ *
+ * @return The result of update_fn
+ *
+ * @thread_safety Thread-safe. Uses shared_lock for reads, unique_lock for writes.
+ *
+ * @note The update_fn is called outside of any lock, so additional
+ *       synchronization may be needed if the value has its own threading
+ *       requirements.
+ *
+ * @example
+ * @code
+ * std::unordered_map<std::string, std::unique_ptr<Counter>> counters;
+ * std::shared_mutex counters_mutex;
+ *
+ * // Get or create and increment
+ * hot_path::get_or_create_and_update(
+ *     counters,
+ *     counters_mutex,
+ *     "requests",
+ *     []() { return std::make_unique<Counter>(); },
+ *     [](Counter& c) { c.increment(); }
+ * );
+ * @endcode
+ */
+template <typename Map, typename Key, typename CreateFn, typename UpdateFn>
+auto get_or_create_and_update(Map& map, std::shared_mutex& mutex, const Key& key,
+                              CreateFn create_fn, UpdateFn update_fn)
+    -> decltype(update_fn(*map.begin()->second)) {
+    // Get or create the entry
+    auto* ptr = get_or_create(map, mutex, key, std::move(create_fn));
+
+    // Apply the update function outside of map locks
+    // The value's own synchronization handles thread safety
+    return update_fn(*ptr);
+}
+
+}  // namespace hot_path
+}  // namespace monitoring
+}  // namespace kcenon

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,6 +138,9 @@ add_executable(monitoring_system_tests
 
     # Statistics utilities tests (Issue #381)
     test_statistics_utils.cpp
+
+    # Hot-path helper tests (Issue #387)
+    test_hot_path_helper.cpp
 )
 
 # Interface compilation test (standalone executable with main())

--- a/tests/test_hot_path_helper.cpp
+++ b/tests/test_hot_path_helper.cpp
@@ -1,0 +1,312 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, monitoring_system contributors
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file test_hot_path_helper.cpp
+ * @brief Unit tests for hot-path optimization helpers
+ */
+
+#include <gtest/gtest.h>
+#include <kcenon/monitoring/utils/hot_path_helper.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+using namespace kcenon::monitoring::hot_path;
+
+namespace {
+
+struct TestData {
+    int value{0};
+    std::string name;
+};
+
+}  // namespace
+
+class HotPathHelperTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        map_.clear();
+    }
+
+    void TearDown() override {}
+
+    std::unordered_map<std::string, std::unique_ptr<TestData>> map_;
+    std::shared_mutex mutex_;
+};
+
+// =========================================================================
+// get_or_create Tests
+// =========================================================================
+
+TEST_F(HotPathHelperTest, GetOrCreateNewEntry) {
+    auto* ptr = get_or_create(
+        map_, mutex_, "key1",
+        []() { return std::make_unique<TestData>(); });
+
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(map_.size(), 1u);
+    EXPECT_EQ(ptr->value, 0);
+}
+
+TEST_F(HotPathHelperTest, GetOrCreateExistingEntry) {
+    // Pre-create an entry
+    map_["key1"] = std::make_unique<TestData>();
+    map_["key1"]->value = 42;
+
+    int create_count = 0;
+    auto* ptr = get_or_create(
+        map_, mutex_, "key1",
+        [&create_count]() {
+            ++create_count;
+            return std::make_unique<TestData>();
+        });
+
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(map_.size(), 1u);
+    EXPECT_EQ(ptr->value, 42);
+    EXPECT_EQ(create_count, 0);  // Factory should not be called
+}
+
+TEST_F(HotPathHelperTest, GetOrCreateMultipleKeys) {
+    auto* ptr1 = get_or_create(
+        map_, mutex_, "key1",
+        []() { return std::make_unique<TestData>(); });
+    auto* ptr2 = get_or_create(
+        map_, mutex_, "key2",
+        []() { return std::make_unique<TestData>(); });
+
+    ASSERT_NE(ptr1, nullptr);
+    ASSERT_NE(ptr2, nullptr);
+    EXPECT_NE(ptr1, ptr2);
+    EXPECT_EQ(map_.size(), 2u);
+}
+
+// =========================================================================
+// get_or_create_with_init Tests
+// =========================================================================
+
+TEST_F(HotPathHelperTest, GetOrCreateWithInitNewEntry) {
+    auto* ptr = get_or_create_with_init(
+        map_, mutex_, "key1",
+        []() { return std::make_unique<TestData>(); },
+        [](TestData& d) {
+            d.value = 100;
+            d.name = "initialized";
+        });
+
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(ptr->value, 100);
+    EXPECT_EQ(ptr->name, "initialized");
+}
+
+TEST_F(HotPathHelperTest, GetOrCreateWithInitExistingEntry) {
+    // Pre-create an entry
+    map_["key1"] = std::make_unique<TestData>();
+    map_["key1"]->value = 42;
+    map_["key1"]->name = "original";
+
+    int init_count = 0;
+    auto* ptr = get_or_create_with_init(
+        map_, mutex_, "key1",
+        []() { return std::make_unique<TestData>(); },
+        [&init_count](TestData& d) {
+            ++init_count;
+            d.value = 100;
+        });
+
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(ptr->value, 42);  // Should not be modified
+    EXPECT_EQ(ptr->name, "original");
+    EXPECT_EQ(init_count, 0);  // Init should not be called
+}
+
+// =========================================================================
+// get_or_create_and_update Tests
+// =========================================================================
+
+TEST_F(HotPathHelperTest, GetOrCreateAndUpdateNewEntry) {
+    int result = get_or_create_and_update(
+        map_, mutex_, "key1",
+        []() { return std::make_unique<TestData>(); },
+        [](TestData& d) {
+            d.value = 42;
+            return d.value;
+        });
+
+    EXPECT_EQ(result, 42);
+    EXPECT_EQ(map_["key1"]->value, 42);
+}
+
+TEST_F(HotPathHelperTest, GetOrCreateAndUpdateExistingEntry) {
+    // Pre-create an entry
+    map_["key1"] = std::make_unique<TestData>();
+    map_["key1"]->value = 10;
+
+    int result = get_or_create_and_update(
+        map_, mutex_, "key1",
+        []() { return std::make_unique<TestData>(); },
+        [](TestData& d) {
+            d.value += 5;
+            return d.value;
+        });
+
+    EXPECT_EQ(result, 15);
+    EXPECT_EQ(map_["key1"]->value, 15);
+}
+
+// =========================================================================
+// Concurrent Access Tests
+// =========================================================================
+
+TEST_F(HotPathHelperTest, ConcurrentGetOrCreate) {
+    std::atomic<int> create_count{0};
+    const int num_threads = 10;
+    const int iterations_per_thread = 1000;
+
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+
+    for (int t = 0; t < num_threads; ++t) {
+        threads.emplace_back([this, &create_count, iterations_per_thread]() {
+            for (int i = 0; i < iterations_per_thread; ++i) {
+                auto* ptr = get_or_create(
+                    map_, mutex_, "shared_key",
+                    [&create_count]() {
+                        ++create_count;
+                        return std::make_unique<TestData>();
+                    });
+                ASSERT_NE(ptr, nullptr);
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(map_.size(), 1u);
+    EXPECT_EQ(create_count.load(), 1);  // Only one creation should occur
+}
+
+TEST_F(HotPathHelperTest, ConcurrentDifferentKeys) {
+    std::atomic<int> total_creates{0};
+    const int num_threads = 10;
+    const int keys_per_thread = 100;
+
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+
+    for (int t = 0; t < num_threads; ++t) {
+        threads.emplace_back([this, t, &total_creates, keys_per_thread]() {
+            for (int i = 0; i < keys_per_thread; ++i) {
+                std::string key = "key_" + std::to_string(t) + "_" + std::to_string(i);
+                auto* ptr = get_or_create(
+                    map_, mutex_, key,
+                    [&total_creates]() {
+                        ++total_creates;
+                        return std::make_unique<TestData>();
+                    });
+                ASSERT_NE(ptr, nullptr);
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(map_.size(), static_cast<size_t>(num_threads * keys_per_thread));
+    EXPECT_EQ(total_creates.load(), num_threads * keys_per_thread);
+}
+
+TEST_F(HotPathHelperTest, ConcurrentMixedReadWrite) {
+    // Pre-create some entries
+    for (int i = 0; i < 50; ++i) {
+        map_["existing_" + std::to_string(i)] = std::make_unique<TestData>();
+    }
+
+    const int num_threads = 8;
+    const int iterations = 500;
+
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+
+    for (int t = 0; t < num_threads; ++t) {
+        threads.emplace_back([this, t, iterations]() {
+            for (int i = 0; i < iterations; ++i) {
+                // Half the time access existing, half the time create new
+                std::string key = (i % 2 == 0)
+                    ? "existing_" + std::to_string(i % 50)
+                    : "new_" + std::to_string(t) + "_" + std::to_string(i);
+
+                auto* ptr = get_or_create(
+                    map_, mutex_, key,
+                    []() { return std::make_unique<TestData>(); });
+                ASSERT_NE(ptr, nullptr);
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_GE(map_.size(), 50u);  // At least the pre-existing entries
+}
+
+// =========================================================================
+// Performance Characteristics Test
+// =========================================================================
+
+TEST_F(HotPathHelperTest, HotPathOptimizationVerification) {
+    // Create entry first
+    map_["hot_key"] = std::make_unique<TestData>();
+
+    std::atomic<int> create_calls{0};
+    const int hot_path_iterations = 10000;
+
+    // Simulate hot path - many reads, no creates
+    for (int i = 0; i < hot_path_iterations; ++i) {
+        auto* ptr = get_or_create(
+            map_, mutex_, "hot_key",
+            [&create_calls]() {
+                ++create_calls;
+                return std::make_unique<TestData>();
+            });
+        ASSERT_NE(ptr, nullptr);
+    }
+
+    // Verify factory was never called (hot path optimization working)
+    EXPECT_EQ(create_calls.load(), 0);
+}


### PR DESCRIPTION
Closes #387

## Summary
- Add `hot_path_helper.h` with reusable double-check locking patterns
- Implement `get_or_create`, `get_or_create_with_init`, and `get_or_create_and_update` templates
- Refactor `record_metric_internal()` to use the new helper
- Add comprehensive unit tests including concurrent access tests

## Test Plan
- [x] All 11 HotPathHelperTest tests pass
- [x] All 41 performance monitoring tests pass
- [x] Build succeeds with Release configuration