### PR TITLE
refactor(factory): integrate collector_registry with builtin collectors

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,6 +81,9 @@ add_executable(monitoring_system_tests
     # Battery status monitoring (Issue #218)
     test_battery_collector.cpp
 
+    # Collector registry integration (Issue #446)
+    test_collector_registry_integration.cpp
+
     # Load average history tracking (Issue #219)
     test_time_series_buffer.cpp
 

--- a/tests/test_collector_registry_integration.cpp
+++ b/tests/test_collector_registry_integration.cpp
@@ -1,0 +1,152 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, kcenon
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "kcenon/monitoring/factory/builtin_collectors.h"
+#include "kcenon/monitoring/plugins/collector_registry.h"
+
+using namespace kcenon::monitoring;
+
+class CollectorRegistryIntegrationTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Clean registry before each test
+        auto& registry = collector_registry::instance();
+        registry.clear();
+    }
+
+    void TearDown() override {
+        // Clean up after test
+        auto& registry = collector_registry::instance();
+        registry.clear();
+    }
+};
+
+// Test that all builtin collectors are registered with the registry
+TEST_F(CollectorRegistryIntegrationTest, BuiltinCollectorsRegisteredWithRegistry) {
+    auto& registry = collector_registry::instance();
+
+    // Register all builtin collectors
+    bool success = register_builtin_collectors();
+    EXPECT_TRUE(success);
+
+    // Check that we have 9 plugin-based collectors registered
+    // (battery, uptime, interrupt, network_metrics, platform_metrics,
+    //  process_metrics, security, smart, vm)
+    auto total_plugins = registry.plugin_count();
+    EXPECT_EQ(total_plugins, 9);
+}
+
+// Test that get_plugins returns all registered collectors
+TEST_F(CollectorRegistryIntegrationTest, GetPluginsReturnsAllCollectors) {
+    auto& registry = collector_registry::instance();
+
+    // Register builtin collectors
+    register_builtin_collectors();
+
+    // Try to get a specific plugin first (safer)
+    auto* battery = registry.get_plugin("battery_collector");
+
+    // If battery collector is available on this platform
+    if (battery != nullptr) {
+        // Check that it has a valid name (the actual implementation uses "battery")
+        EXPECT_FALSE(std::string(battery->name()).empty());
+    }
+
+    // Check plugin count
+    auto total_plugins = registry.plugin_count();
+    EXPECT_EQ(total_plugins, 9);
+}
+
+// Test registry statistics
+TEST_F(CollectorRegistryIntegrationTest, RegistryStatistics) {
+    auto& registry = collector_registry::instance();
+
+    // Register builtin collectors
+    register_builtin_collectors();
+
+    // Get statistics (without triggering full instantiation)
+    auto stats = registry.get_registry_stats();
+
+    // Should have total_plugins stat
+    EXPECT_TRUE(stats.find("total_plugins") != stats.end());
+}
+
+// Test that specific collectors can be retrieved
+TEST_F(CollectorRegistryIntegrationTest, GetSpecificCollector) {
+    auto& registry = collector_registry::instance();
+
+    // Register builtin collectors
+    register_builtin_collectors();
+
+    // Try to get battery_collector
+    auto* battery = registry.get_plugin("battery_collector");
+
+    // Should either be valid or null (if not available on platform)
+    if (battery != nullptr) {
+        // Check that it has a valid name
+        EXPECT_FALSE(std::string(battery->name()).empty());
+    }
+}
+
+// Test initialization of all plugins
+TEST_F(CollectorRegistryIntegrationTest, InitializeAllPlugins) {
+    auto& registry = collector_registry::instance();
+
+    // Register builtin collectors
+    register_builtin_collectors();
+
+    // Get a specific plugin
+    auto* uptime = registry.get_plugin("uptime_collector");
+
+    if (uptime != nullptr) {
+        // Initialize this specific plugin
+        config_map config;
+        bool init_result = uptime->initialize(config);
+        EXPECT_TRUE(init_result);
+    }
+}
+
+// Test that has_plugin works correctly
+TEST_F(CollectorRegistryIntegrationTest, HasPlugin) {
+    auto& registry = collector_registry::instance();
+
+    // Register builtin collectors
+    register_builtin_collectors();
+
+    // Should have battery_collector registered
+    EXPECT_TRUE(registry.has_plugin("battery_collector"));
+
+    // Should have uptime_collector registered
+    EXPECT_TRUE(registry.has_plugin("uptime_collector"));
+
+    // Should not have a non-existent collector
+    EXPECT_FALSE(registry.has_plugin("non_existent_collector"));
+}


### PR DESCRIPTION
## Summary
- Integrated collector_registry with builtin collectors for runtime plugin management
- All 9 collector_plugin-based collectors now registered with collector_registry
- Maintained backward compatibility with metric_factory
- Added comprehensive integration tests

## Changes Made

### Modified Files
1. **include/kcenon/monitoring/factory/builtin_collectors.h**
   - Added collector_registry include
   - Updated register_builtin_collectors() to use both collector_registry and metric_factory
   - Registered 9 plugin-based collectors with collector_registry using factory pattern
   - Updated documentation to reflect dual registration approach

2. **tests/CMakeLists.txt**
   - Added test_collector_registry_integration.cpp to test suite

3. **tests/test_collector_registry_integration.cpp** (new)
   - Created 6 integration test cases
   - Tests plugin registration, retrieval, and statistics
   - Validates has_plugin and initialization functionality

### Collectors Registered with collector_registry
- battery_collector
- uptime_collector
- interrupt_collector
- network_metrics_collector
- platform_metrics_collector
- process_metrics_collector
- security_collector
- smart_collector
- vm_collector

**Note**: system_resource_collector remains in metric_factory only as it implements
metric_collector_plugin interface instead of collector_plugin.

## Test Plan
- [x] All new integration tests pass (6/6)
- [x] Existing tests remain stable (783/786 passing)
- [x] Build succeeds with no warnings
- [x] Plugin count verification: 9 collectors registered
- [x] has_plugin() works correctly
- [x] get_plugin() retrieves collectors successfully

## Acceptance Criteria
- [x] builtin_collectors.h uses collector_registry
- [x] All 9 plugin-based collectors registered with collector_registry
- [x] Collectors can be accessed via registry.get_plugin()
- [x] registry.has_plugin() correctly identifies registered collectors
- [x] Backward compatibility with metric_factory maintained
- [x] Build succeeds
- [x] Tests pass

## Related Issues
Closes #446
Part of #423 (Epic: Implement Collector plugin architecture)

## Technical Notes

### Design Decision: Dual Registration
Both collector_registry and metric_factory registration are maintained because:
1. **collector_registry**: Provides runtime plugin management for collector_plugin interface
2. **metric_factory**: Maintains backward compatibility with existing code

### Future Work
- Consider migrating system_resource_collector to collector_plugin interface
- Deprecate metric_factory in favor of collector_registry (breaking change)
- Add runtime enable/disable configuration support