### PR TITLE
docs(core): expand ARCHITECTURE.md with detailed system design

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ The system comprises 15+ modules organized in a layered architecture. Dependenci
 │  │ core         │ │_interface     │ │_interface   │ │interface   │  │
 │  └──────────────┘ └───────────────┘ └────────────┘ └────────────┘  │
 │  ┌──────────────┐ ┌───────────────┐                                 │
-│  │ observer_    │ │ monitoring_   │  (C++20 concepts: 12 concepts)  │
+│  │ observer_    │ │ monitoring_   │  (C++20 concepts: 14 concepts)  │
 │  │ interface    │ │ concepts.h    │                                  │
 │  └──────────────┘ └───────────────┘                                 │
 └──────────────────────────┬──────────────────────────────────────────┘
@@ -536,7 +536,7 @@ thread_system ──(metrics)──► monitoring_system ◄──(metrics)─�
 
 ### C++20 Concepts
 
-`concepts/monitoring_concepts.h` defines 12 compile-time constraints:
+`concepts/monitoring_concepts.h` defines 14 compile-time constraints:
 
 | Concept | Constrains | Requirements |
 |---------|-----------|--------------|
@@ -544,6 +544,7 @@ thread_system ──(metrics)──► monitoring_system ◄──(metrics)─�
 | `MetricType` | Metric structures | Class with `.name` and `.value` |
 | `MetricSourceLike` | Data sources | `get_current_metrics()`, `get_source_name()`, `is_healthy()` |
 | `MetricCollectorLike` | Collectors | `collect_metrics()`, `is_collecting()`, `get_metric_types()` |
+| `ObserverLike` | Observers | `on_metrics_updated()` |
 | `MonitoringEventType` | Events | Class, copy-constructible |
 | `MonitoringEventHandler<E>` | Event handlers | Invocable with `const E&`, returns void |
 | `MetricFilterPredicate<M>` | Filters | Invocable with `const M&`, returns bool |
@@ -638,18 +639,18 @@ thread_system ──(metrics)──► monitoring_system ◄──(metrics)─�
 
 ```
 include/kcenon/monitoring/
-├── core/                    # Core pipeline (7 headers)
+├── core/                    # Core pipeline (9 headers)
 ├── interfaces/              # Abstract contracts (6 headers)
 ├── concepts/                # C++20 concepts (1 header)
-├── collectors/              # Metric collectors (17 headers)
+├── collectors/              # Metric collectors (18 headers)
 ├── plugins/                 # Optional plugins (6 headers)
 │   ├── hardware/            # Battery, power, temp, GPU
 │   └── container/           # Docker, SMART
 ├── storage/                 # Storage backends (1 header, 5 backends)
 ├── exporters/               # Data export (7 headers)
-├── adapters/                # Cross-system adapters (8 headers)
-├── reliability/             # Fault tolerance (5 headers)
-├── alert/                   # Alert pipeline (6 headers)
+├── adapters/                # Cross-system adapters (10 headers)
+├── reliability/             # Fault tolerance (7 headers)
+├── alert/                   # Alert pipeline (7 headers)
 ├── tracing/                 # Distributed tracing (2 headers)
 ├── health/                  # Health monitoring (1 header)
 ├── optimization/            # Performance optimization (3 headers)
@@ -658,7 +659,7 @@ include/kcenon/monitoring/
 ├── di/                      # Dependency injection (1 header)
 ├── factory/                 # Factory patterns (3 headers)
 ├── config/                  # Feature flags (1 header)
-├── utils/                   # Utilities (6 headers)
+├── utils/                   # Utilities (10 headers)
 ├── compatibility.h          # Backward compatibility
 └── forward.h                # Forward declarations
 ```


### PR DESCRIPTION
Closes #454

## Summary
- Expanded `docs/ARCHITECTURE.md` from 60 lines to 686 lines with comprehensive system design documentation
- All content derived from actual source code analysis of 80+ headers across 15+ modules
- Added ASCII diagrams for module dependencies, data flow, threading model, and plugin architecture

## Sections Added
1. **System Architecture Diagram** - Module dependency graph, data flow from collection to export, event bus pub/sub topology
2. **Core Pipeline Architecture** - `thread_local_buffer` → `central_collector` flow, event bus routing, safe event dispatcher, performance monitor orchestration, error handling flow
3. **Threading Model** - Thread-local buffer design, thread context management, lock-free queue, fine-grained locking strategy, concurrency summary table
4. **Plugin Architecture** - Plugin lifecycle, CRTP collector base pattern, core collectors table, plugin registry and loader
5. **Storage Layer** - Backend abstraction (10 types), factory pattern, configuration examples
6. **Adapter & Interface Layer** - Cross-system integration (thread/logger/common adapters), DI container, C++20 concepts reference (14 concepts)
7. **Design Decisions** - Rationale for event bus, thread-local buffering, CRTP, plugin architecture, Result<T> pattern, C++20 concepts

## Test Plan
- [x] Document exceeds 300 lines (686 lines, up from 60)
- [x] Architecture diagram with all 15+ modules
- [x] Data flow diagram from collection to export
- [x] Threading model fully explained
- [x] Plugin architecture documented
- [x] Storage layer architecture covered
- [x] Design decisions documented with rationale
- [x] Verify all referenced headers exist in codebase (40/40 headers verified)
- [x] Review for consistency with existing documentation (terminology matches ARCHITECTURE_GUIDE.md, PROJECT_STRUCTURE.md)

## Verification Notes
- **Header existence**: All 40 explicitly referenced header paths verified against actual codebase
- **Header counts**: Fixed inaccurate counts in Module Reference section (core 7→9, collectors 17→18, adapters 8→10, reliability 5→7, alert 6→7, utils 6→10)
- **Concept count**: Fixed from 12→14, added missing `ObserverLike` concept to table
- **Consistency**: Core terminology (Result<T>, CRTP, event_bus, thread_local_buffer) consistent across all documentation