### PR TITLE
ci(doxygen): replace workflow with reusable template

### DIFF
--- a/.github/workflows/build-Doxygen.yaml
+++ b/.github/workflows/build-Doxygen.yaml
@@ -2,61 +2,14 @@ name: Generate-Documentation
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 jobs:
-  generate_docs:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          ssh-strict: true
-          ssh-user: git
-          persist-credentials: true
-          clean: true
-          sparse-checkout-cone-mode: true
-          fetch-depth: 1
-          fetch-tags: false
-          show-progress: true
-          lfs: false
-          set-safe-directory: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout common_system dependency
-        uses: actions/checkout@v4
-        with:
-          repository: kcenon/common_system
-          path: common_system
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Doxygen
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y doxygen graphviz
-
-      - name: Cache Doxygen output
-        uses: actions/cache@v3
-        with:
-          path: ./documents/html
-          key: ${{ runner.os }}-doxygen-${{ hashFiles('**/*.h', '**/*.cpp', 'Doxyfile') }}
-          restore-keys: |
-            ${{ runner.os }}-doxygen-
-
-      - name: Generate Documentation
-        run: doxygen Doxyfile
-
-      - name: Deploy Documentation
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./documents/html
-          commit_message: "Update documentation via GitHub Actions"
-          enable_jekyll: false
+  docs:
+    uses: kcenon/common_system/.github/workflows/doxygen.yml@main
+    with:
+      checkout-common-system: true
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replace inline Doxygen workflow with a call to the shared reusable workflow in `kcenon/common_system`
- Uses `checkout-common-system: true` to checkout the dependency
- Removes Doxygen output cache and redundant checkout options
- Standardizes on `actions/checkout@v5`, `peaceiris/actions-gh-pages@v4`
- Adds `force_orphan: true`, deploy guard, `[skip ci]` commit message

## Context
Part of cross-repo Doxygen workflow unification. Depends on kcenon/common_system#362.

## Test plan
- [ ] ~CI generates docs successfully on PR~ (Doxygen workflow not visible in PR checks)
- [x] After merge, gh-pages updates correctly
- [x] `https://kcenon.github.io/monitoring_system/` serves documentation
