### PR TITLE
chore(deps): pin gRPC and protobuf minimum versions

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -15,8 +15,14 @@
     "grpc": {
       "description": "Enable gRPC transport for OTLP trace export",
       "dependencies": [
-        "grpc",
-        "protobuf"
+        {
+          "name": "grpc",
+          "version>=": "1.51.1"
+        },
+        {
+          "name": "protobuf",
+          "version>=": "3.21.0"
+        }
       ]
     },
     "logging": {


### PR DESCRIPTION
## Summary

- Pin `grpc` to `>= 1.51.1` (security fixes)
- Pin `protobuf` to `>= 3.21.0` (proto3 optional field support)

Aligns with logger_system OTLP dependency versions and ensures SOUP traceability per IEC 62304.

## Test Plan

- [x] `vcpkg.json` passes JSON validation
- [x] CI build succeeds

Closes #487