### PR TITLE
Add vcpkg version overrides for IEC 62304 compliance

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,6 +11,11 @@
     "kcenon-common-system",
     "kcenon-thread-system"
   ],
+  "overrides": [
+    { "name": "grpc", "version": "1.51.1" },
+    { "name": "protobuf", "version": "3.21.12" },
+    { "name": "gtest", "version": "1.14.0" }
+  ],
   "features": {
     "grpc": {
       "description": "Enable gRPC transport for OTLP trace export",


### PR DESCRIPTION
## Summary
Add vcpkg version overrides to pin exact SOUP versions for IEC 62304 Clause 8.1.2 compliance (configuration items shall be uniquely identified).

Versions are pinned from vcpkg baseline c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d.

## Motivation
- Closes the gap between web/server SOUP version pinning (npm ci, pip --require-hashes) and C++ ecosystem
- Ensures reproducible builds even if vcpkg baseline is updated
- Refs kcenon/flonics_project#245

## Test plan
- [x] Verify vcpkg.json is valid JSON
- [x] Verify overrides match baseline versions
- [x] Verify CI build succeeds with pinned versions
