### PR TITLE
chore(ci): Graduate sanitizer jobs from Phase 0 to Phase 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,11 +316,9 @@ jobs:
         path: build/Testing/
         retention-days: 7
 
-  # Phase 0: Allow failures, just collect data
   sanitizers:
     name: Sanitizers (${{ matrix.sanitizer }})
     runs-on: ubuntu-24.04
-    continue-on-error: true
     timeout-minutes: 60
 
     strategy:
@@ -411,7 +409,7 @@ jobs:
         export ${{ matrix.sanitizer.env }}
         find bin -name "*_unit" -executable 2>/dev/null | while read test; do
           echo "Running $test with ${{ matrix.sanitizer.name }}..."
-          ./$test || echo "${{ matrix.sanitizer.name }} detected issues (expected in Phase 0)"
+          ./$test
         done
 
     - name: Upload sanitizer logs

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -166,12 +166,10 @@ jobs:
       run: |
         echo "# Sanitizer Test Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "## Phase 0: Baseline Establishment" >> $GITHUB_STEP_SUMMARY
+        echo "## Phase 1: Sanitizer Failures Block Merges" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Sanitizer tests are configured and running." >> $GITHUB_STEP_SUMMARY
-        echo "Current phase allows warnings - focus is on establishing baseline." >> $GITHUB_STEP_SUMMARY
+        echo "Current phase enforces sanitizer checks - failures block merges." >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
-        echo "- Document baseline sanitizer warnings" >> $GITHUB_STEP_SUMMARY
-        echo "- Phase 1 will address thread safety issues" >> $GITHUB_STEP_SUMMARY
-        echo "- Phase 2 will address memory management issues" >> $GITHUB_STEP_SUMMARY
+        echo "- Phase 2 will address remaining memory management issues" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from sanitizer job in ci.yml
- Remove `|| echo` fallbacks from sanitizer test execution
- Update sanitizers.yml summary text to Phase 1

## Test plan
- [x] ASan CI job passes
- [x] TSan CI job passes
- [x] UBSan CI job passes

Refs: kcenon/common_system#394
