### PR TITLE
docs(legal): pin internal dependency provenance

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -59,60 +59,8 @@ jobs:
       with:
         sarif_file: ${{ steps.grype-scan.outputs.sarif }}
 
-    - name: Parse vcpkg dependencies
-      run: |
-        if [ -f "vcpkg.json" ]; then
-          python3 << 'PYEOF' > vcpkg-dependencies.md
-        import json
-
-        with open('vcpkg.json', 'r') as f:
-            manifest = json.load(f)
-
-        print("# vcpkg Dependencies")
-        print()
-        print(f"**Project**: {manifest.get('name', 'N/A')}")
-        print(f"**Version**: {manifest.get('version', 'N/A')}")
-        print()
-        print("## Direct Dependencies")
-        print()
-        print("| Package | Version Constraint | Features |")
-        print("|---------|-------------------|----------|")
-
-        deps = manifest.get('dependencies', [])
-        for dep in deps:
-            if isinstance(dep, str):
-                print(f"| {dep} | - | - |")
-            elif isinstance(dep, dict):
-                name = dep.get('name', 'unknown')
-                version = dep.get('version>=', '-')
-                features = ', '.join(dep.get('features', [])) or '-'
-                print(f"| {name} | {version} | {features} |")
-
-        features = manifest.get('features', {})
-        if features:
-            print()
-            print("## Feature Dependencies")
-            print()
-            for feat_name, feat_data in features.items():
-                feat_deps = feat_data.get('dependencies', [])
-                if feat_deps:
-                    print(f"### {feat_name}")
-                    print()
-                    print("| Package | Version Constraint | Features |")
-                    print("|---------|-------------------|----------|")
-                    for dep in feat_deps:
-                        if isinstance(dep, str):
-                            print(f"| {dep} | - | - |")
-                        elif isinstance(dep, dict):
-                            name = dep.get('name', 'unknown')
-                            version = dep.get('version>=', '-')
-                            dep_features = ', '.join(dep.get('features', [])) or '-'
-                            print(f"| {name} | {version} | {dep_features} |")
-                    print()
-        PYEOF
-        else
-          echo "No vcpkg.json found" > vcpkg-dependencies.md
-        fi
+    - name: Generate dependency inventory report
+      run: python3 scripts/ci/generate_dependency_report.py > vcpkg-dependencies.md
 
     - name: Create combined SBOM report
       run: |

--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -27,6 +27,7 @@ monitoring_system (Tier 3, BSD-3-Clause)
 | Component          | kcenon Common System                           |
 | License            | BSD-3-Clause                                   |
 | Pinned Version     | 0.2.0                                          |
+| Provenance Rule    | Resolve via the pinned vcpkg baseline `c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d`; source builds must record the exact git tag or commit SHA in the release SBOM |
 | Usage              | ILogger interface, Result<T> pattern, common utilities |
 | Linking            | Static                                         |
 | BSD-3 Compatible   | Yes                                            |
@@ -39,6 +40,7 @@ monitoring_system (Tier 3, BSD-3-Clause)
 | Component          | kcenon Thread System                           |
 | License            | BSD-3-Clause                                   |
 | Pinned Version     | 0.3.0                                          |
+| Provenance Rule    | Resolve via the pinned vcpkg baseline `c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d`; source builds must record the exact git tag or commit SHA in the release SBOM |
 | Usage              | Thread pool, async task management, lock-free queues |
 | Linking            | Static                                         |
 | BSD-3 Compatible   | Yes                                            |
@@ -51,6 +53,7 @@ monitoring_system (Tier 3, BSD-3-Clause)
 | Component          | kcenon Logger System                           |
 | License            | BSD-3-Clause                                   |
 | Pinned Version     | 0.1.0                                          |
+| Provenance Rule    | Use overlay/vcpkg port version `0.1.0` when the `logging` feature is enabled; source builds must record the exact git tag or commit SHA in the release SBOM |
 | Usage              | Audit logging, async log output                |
 | Linking            | Static                                         |
 | BSD-3 Compatible   | Yes                                            |
@@ -91,6 +94,19 @@ automatically via the vcpkg dependency chain:
 | BSD-3 Compatible   | Yes                                            |
 | Condition          | Enabled when MONITORING_WITH_GRPC=ON           |
 
+## network_system (Optional — MONITORING_WITH_NETWORK_SYSTEM)
+
+| Item               | Value                                          |
+|--------------------|--------------------------------------------- --|
+| Component          | kcenon Network System                          |
+| License            | BSD-3-Clause                                   |
+| Pinned Version     | Source-defined                                 |
+| Provenance Rule    | Source-resolved integration only; release SBOMs must record the exact git tag or commit SHA because the root vcpkg manifest does not pin a package version |
+| Usage              | HTTP transport backend for exporters           |
+| Linking            | Runtime/source integration                     |
+| BSD-3 Compatible   | Yes                                            |
+| Condition          | Enabled when MONITORING_WITH_NETWORK_SYSTEM=ON |
+
 ## All Dependencies (License Summary)
 
 | Dependency         | License        | Type     | Tier | BSD-3 Compatible |
@@ -98,6 +114,7 @@ automatically via the vcpkg dependency chain:
 | common_system      | BSD-3-Clause   | Required | 0    | Yes              |
 | thread_system      | BSD-3-Clause   | Required | 1    | Yes              |
 | logger_system      | BSD-3-Clause   | Optional | 2    | Yes              |
+| network_system     | BSD-3-Clause   | Optional | 4    | Yes              |
 | gRPC               | Apache-2.0     | Optional | —    | Yes              |
 | Protocol Buffers   | BSD-3-Clause   | Optional | —    | Yes              |
 | abseil (via gRPC)  | Apache-2.0     | Transitive | —  | Yes              |

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Modern C++20 observability platform with comprehensive monitoring, distributed t
 |------------|---------|----------|-------------|
 | C++20 Compiler | GCC 13+ / Clang 17+ / MSVC 2022+ / Apple Clang 14+ | Yes | Higher requirements due to thread_system dependency |
 | CMake | 3.20+ | Yes | Build system |
-| [common_system](https://github.com/kcenon/common_system) | latest | Yes | Common interfaces (IMonitor, Result<T>) |
-| [thread_system](https://github.com/kcenon/thread_system) | latest | Yes | Thread pool and async operations |
-| [logger_system](https://github.com/kcenon/logger_system) | latest | Optional | Logging capabilities |
+| [common_system](https://github.com/kcenon/common_system) | 0.2.0 via overlay/vcpkg port, or exact source tag/commit recorded in SBOM | Yes | Common interfaces (IMonitor, Result<T>) |
+| [thread_system](https://github.com/kcenon/thread_system) | 0.3.0 via overlay/vcpkg port, or exact source tag/commit recorded in SBOM | Yes | Thread pool and async operations |
+| [logger_system](https://github.com/kcenon/logger_system) | 0.1.0 when `logging` is enabled, or exact source tag/commit recorded in SBOM | Optional | Logging capabilities |
 
 ### Dependency Flow
 
@@ -41,6 +41,15 @@ monitoring_system
 └── logger_system (optional)
     └── common_system
 ```
+
+### Feature and Build-Path Provenance
+
+| Path | Activation | Dependencies | Provenance Rule |
+|------|------------|--------------|-----------------|
+| Default root package | `vcpkg install kcenon-monitoring-system` | `kcenon-common-system`, `kcenon-thread-system` | Resolve through the pinned vcpkg baseline `c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d` and the package versions documented in `docs/guides/VCPKG_OVERLAY_PORTS.md` |
+| Logging integration | `kcenon-monitoring-system[logging]` or `-DMONITORING_WITH_LOGGER_SYSTEM=ON` | `kcenon-logger-system` | Use port version `0.1.0` when installed from vcpkg/overlay; for source builds record the exact git tag or commit SHA in the SBOM |
+| gRPC transport | `kcenon-monitoring-system[grpc]` or `-DMONITORING_WITH_GRPC=ON` | `grpc`, `protobuf` | Use `vcpkg.json` override versions (`grpc` `1.51.1`, `protobuf` `3.21.12`) |
+| Network export path | `-DMONITORING_WITH_NETWORK_SYSTEM=ON` | `network_system` | Source-resolved integration only; release SBOMs must record the exact git tag or commit SHA because the root manifest does not pin a package version |
 
 ### Building with Dependencies
 
@@ -66,9 +75,10 @@ cmake --build build
 Part of a modular C++ ecosystem with clean interface boundaries:
 
 **Dependencies**:
-- **[common_system](https://github.com/kcenon/common_system)**: Core interfaces (IMonitor, ILogger, Result<T>)
-- **[thread_system](https://github.com/kcenon/thread_system)**: Threading primitives (required)
-- **[logger_system](https://github.com/kcenon/logger_system)**: Logging capabilities (optional)
+- **[common_system](https://github.com/kcenon/common_system)**: Core interfaces (IMonitor, ILogger, Result<T>), provenance `0.2.0` or exact source revision
+- **[thread_system](https://github.com/kcenon/thread_system)**: Threading primitives (required), provenance `0.3.0` or exact source revision
+- **[logger_system](https://github.com/kcenon/logger_system)**: Logging capabilities (optional), provenance `0.1.0` or exact source revision
+- **[network_system](https://github.com/kcenon/network_system)**: HTTP transport backend for exporter paths enabled via `MONITORING_WITH_NETWORK_SYSTEM`, source revision must be captured in SBOM
 
 **Integration Pattern**:
 ```

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -8,17 +8,17 @@
 | Document | Version |
 |----------|---------|
 | IEC 62304 Reference | &sect;8.1.2 Software items from SOUP |
-| Last Reviewed | 2026-03-06 |
+| Last Reviewed | 2026-03-10 |
 | monitoring_system Version | 2.0.0 |
 
 ---
 
 ## Internal Ecosystem Dependencies
 
-| ID | Name | Manufacturer | Version | License | Usage | Safety Class | Known Anomalies |
-|----|------|-------------|---------|---------|-------|-------------|-----------------|
-| INT-001 | [common_system](https://github.com/kcenon/common_system) | kcenon | Latest (vcpkg / source) | BSD-3-Clause | Result&lt;T&gt; pattern, error handling primitives | B | None |
-| INT-002 | [thread_system](https://github.com/kcenon/thread_system) | kcenon | Latest (vcpkg / source) | BSD-3-Clause | Thread pool, async task scheduling for metric collection | B | None |
+| ID | Name | Manufacturer | Version | Provenance Rule | License | Usage | Safety Class | Known Anomalies |
+|----|------|-------------|---------|-----------------|---------|-------|-------------|-----------------|
+| INT-001 | [common_system](https://github.com/kcenon/common_system) | kcenon | 0.2.0 | Resolve via the vcpkg baseline `c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d`; source builds must record the exact git tag or commit SHA in the release SBOM | BSD-3-Clause | Result&lt;T&gt; pattern, error handling primitives | B | None |
+| INT-002 | [thread_system](https://github.com/kcenon/thread_system) | kcenon | 0.3.0 | Resolve via the vcpkg baseline `c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d`; source builds must record the exact git tag or commit SHA in the release SBOM | BSD-3-Clause | Thread pool, async task scheduling for metric collection | B | None |
 
 ---
 
@@ -41,17 +41,17 @@
 | SOUP-002 | [gRPC](https://github.com/grpc/grpc) | Google | 1.51.1 | Apache-2.0 | RPC transport for OTLP trace export | A | None |
 | SOUP-003 | [Protocol Buffers](https://github.com/protocolbuffers/protobuf) | Google | 3.21.12 | BSD-3-Clause | Serialization for gRPC transport | A | None |
 
-### Logging Feature (`logging`)
+### Logging Feature (`logging` / `MONITORING_WITH_LOGGER_SYSTEM`)
 
-| ID | Name | Manufacturer | Version | License | Usage | Safety Class | Known Anomalies |
-|----|------|-------------|---------|---------|-------|-------------|-----------------|
-| INT-003 | [logger_system](https://github.com/kcenon/logger_system) | kcenon | Latest (vcpkg / source) | BSD-3-Clause | Audit logging integration (optional) | A | None |
+| ID | Name | Manufacturer | Version | Provenance Rule | License | Usage | Safety Class | Known Anomalies |
+|----|------|-------------|---------|-----------------|---------|-------|-------------|-----------------|
+| INT-003 | [logger_system](https://github.com/kcenon/logger_system) | kcenon | 0.1.0 | Use overlay/vcpkg port version `0.1.0` when the `logging` feature is enabled; source builds must record the exact git tag or commit SHA in the release SBOM | BSD-3-Clause | Audit logging integration (optional) | A | None |
 
-### Network Feature (optional)
+### Network Export Path (`MONITORING_WITH_NETWORK_SYSTEM`)
 
-| ID | Name | Manufacturer | Version | License | Usage | Safety Class | Known Anomalies |
-|----|------|-------------|---------|---------|-------|-------------|-----------------|
-| INT-004 | [network_system](https://github.com/kcenon/network_system) | kcenon | Latest (source) | BSD-3-Clause | Network transport for distributed monitoring (optional) | B | None |
+| ID | Name | Manufacturer | Version | Provenance Rule | License | Usage | Safety Class | Known Anomalies |
+|----|------|-------------|---------|-----------------|---------|-------|-------------|-----------------|
+| INT-004 | [network_system](https://github.com/kcenon/network_system) | kcenon | Source-defined | This path is activated only by the CMake option `MONITORING_WITH_NETWORK_SYSTEM`; release SBOMs must record the exact git tag or commit SHA because the root vcpkg manifest does not pin a package version | BSD-3-Clause | Network transport for distributed monitoring exporters (optional) | B | None |
 
 ---
 
@@ -73,21 +73,62 @@
 
 ---
 
-## Version Pinning (IEC 62304 Compliance)
+## Version Pinning and Provenance Rules (IEC 62304 Compliance)
 
-All SOUP versions are pinned in `vcpkg.json` via the `overrides` field:
+Third-party versions are pinned in `vcpkg.json`, while internal ecosystem
+dependencies are resolved either through the repository's pinned vcpkg baseline
+or through a source-build policy that requires recording an exact git tag or
+commit SHA in the release SBOM.
 
 ```json
 {
+  "dependencies": [
+    "kcenon-common-system",
+    "kcenon-thread-system"
+  ],
   "overrides": [
     { "name": "grpc", "version": "1.51.1" },
     { "name": "protobuf", "version": "3.21.12" },
     { "name": "gtest", "version": "1.14.0" }
-  ]
+  ],
+  "features": {
+    "logging": {
+      "dependencies": [
+        "kcenon-logger-system"
+      ]
+    },
+    "grpc": {
+      "dependencies": [
+        {
+          "name": "grpc",
+          "version>=": "1.51.1"
+        },
+        {
+          "name": "protobuf",
+          "version>=": "3.21.0"
+        }
+      ]
+    }
+  }
 }
 ```
 
-The vcpkg baseline is locked in `vcpkg-configuration.json` to ensure reproducible builds.
+The vcpkg baseline is locked in `vcpkg-configuration.json`:
+
+```json
+{
+  "default-registry": {
+    "baseline": "c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d"
+  }
+}
+```
+
+## Feature-Specific SBOM Guidance
+
+- Default builds should list `kcenon-common-system` and `kcenon-thread-system` as required internal dependencies.
+- `logging` builds should add `kcenon-logger-system` as a feature-scoped internal dependency.
+- `grpc` builds should add `grpc` and `protobuf` as feature-scoped third-party dependencies.
+- `MONITORING_WITH_NETWORK_SYSTEM=ON` builds should annotate `network_system` as a source-resolved CMake integration and record the exact git tag or commit SHA used for that build.
 
 ---
 
@@ -95,7 +136,7 @@ The vcpkg baseline is locked in `vcpkg-configuration.json` to ensure reproducibl
 
 When updating any SOUP dependency:
 
-1. Update the version in `vcpkg.json` (overrides section)
+1. Update the version or provenance rule in `vcpkg.json`, `vcpkg-configuration.json`, or the build documentation as applicable
 2. Update the corresponding row in this document
 3. Verify no new known anomalies (check CVE databases)
 4. Run full CI/CD pipeline to confirm compatibility
@@ -108,6 +149,7 @@ When updating any SOUP dependency:
 | License | Count | Copyleft | Obligation |
 |---------|-------|----------|------------|
 | Apache-2.0 | 1 | No | Include license + NOTICE file |
-| BSD-3-Clause | 1 | No | Include copyright + no-endorsement clause |
+| BSD-3-Clause | 4 | No | Include copyright + no-endorsement clause |
+| MIT | 0-1 | No | Include copyright notice when the network export path pulls in MIT-licensed transitive components |
 
-> **GPL contamination**: None detected. All dependencies are permissively licensed.
+> **GPL contamination**: None detected. All documented dependencies are permissively licensed.

--- a/scripts/ci/generate_dependency_report.py
+++ b/scripts/ci/generate_dependency_report.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Generate a dependency report that distinguishes feature-specific paths."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "vcpkg.json"
+VCPKG_CONFIG_PATH = REPO_ROOT / "vcpkg-configuration.json"
+
+
+INTERNAL_PROVENANCE = {
+    "kcenon-common-system": {
+        "version": "0.2.0",
+        "rule": "Pinned by overlay/vcpkg port version 0.2.0 and the repository baseline; source builds must record exact git tag or commit SHA",
+        "path": "default",
+    },
+    "kcenon-thread-system": {
+        "version": "0.3.0",
+        "rule": "Pinned by overlay/vcpkg port version 0.3.0 and the repository baseline; source builds must record exact git tag or commit SHA",
+        "path": "default",
+    },
+    "kcenon-logger-system": {
+        "version": "0.1.0",
+        "rule": "Optional logging feature dependency; source builds must record exact git tag or commit SHA",
+        "path": "logging",
+    },
+    "network_system": {
+        "version": "source-defined",
+        "rule": "CMake-only integration; release SBOMs must capture the exact git tag or commit SHA",
+        "path": "network",
+    },
+}
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def format_dependency(dep: str | dict) -> tuple[str, str, str]:
+    if isinstance(dep, str):
+        return dep, "-", "-"
+
+    return (
+        dep.get("name", "unknown"),
+        dep.get("version>=", "-"),
+        ", ".join(dep.get("features", [])) or "-",
+    )
+
+
+def print_table(headers: tuple[str, ...], rows: list[tuple[str, ...]]) -> None:
+    widths = ["-" * len(header) for header in headers]
+    print("| " + " | ".join(headers) + " |")
+    print("| " + " | ".join(widths) + " |")
+    for row in rows:
+        print("| " + " | ".join(row) + " |")
+
+
+def main() -> int:
+    manifest = read_json(MANIFEST_PATH)
+    vcpkg_config = read_json(VCPKG_CONFIG_PATH)
+    baseline = vcpkg_config["default-registry"]["baseline"]
+    overrides = {item["name"]: item["version"] for item in manifest.get("overrides", [])}
+
+    print("# Dependency Inventory")
+    print()
+    print(f"**Project**: {manifest.get('name', 'N/A')}")
+    print(f"**Version**: {manifest.get('version', 'N/A')}")
+    print(f"**Pinned vcpkg baseline**: `{baseline}`")
+    print()
+
+    print("## Default Build")
+    print()
+    default_rows: list[tuple[str, ...]] = []
+    for dep in manifest.get("dependencies", []):
+        dep_name = dep if isinstance(dep, str) else dep.get("name", "unknown")
+        meta = INTERNAL_PROVENANCE.get(dep_name, {})
+        default_rows.append(
+            (
+                dep_name,
+                meta.get("version", "-"),
+                meta.get("rule", "Document exact source provenance in the release SBOM"),
+            )
+        )
+    print_table(("Dependency", "Version", "Provenance Rule"), default_rows)
+    print()
+
+    print("## vcpkg Feature Paths")
+    print()
+    for feature_name, feature_data in manifest.get("features", {}).items():
+        print(f"### {feature_name}")
+        print()
+        rows: list[tuple[str, ...]] = []
+        for dep in feature_data.get("dependencies", []):
+            name, version, features = format_dependency(dep)
+            meta = INTERNAL_PROVENANCE.get(name, {})
+            resolved_version = meta.get("version", overrides.get(name, version))
+            rule = meta.get("rule", "Pinned through manifest feature dependency")
+            if features != "-":
+                rule = f"{rule}; features: {features}"
+            rows.append((name, resolved_version, rule))
+        if rows:
+            print_table(("Dependency", "Version", "Provenance Rule"), rows)
+        else:
+            print("No additional dependencies.")
+        print()
+
+    print("## CMake-Only Optional Paths")
+    print()
+    print_table(
+        ("Path", "Activation", "Dependency", "Provenance Rule"),
+        [
+            (
+                "Network export path",
+                "`-DMONITORING_WITH_NETWORK_SYSTEM=ON`",
+                "network_system",
+                INTERNAL_PROVENANCE["network_system"]["rule"],
+            ),
+        ],
+    )
+    print()
+    print(
+        "Interpret feature-specific SBOMs by combining the default build dependencies "
+        "with the rows from each enabled vcpkg feature and any active CMake-only optional paths."
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Background

`monitoring_system` documented internal kcenon ecosystem dependencies such as `common_system`, `thread_system`, `logger_system`, and `network_system` as `Latest` or generic source references, which is too weak for SOUP traceability. The build already distinguishes default dependencies, optional vcpkg features, and CMake-only integration paths, but that distinction was not clearly reflected in the legal and SBOM guidance.

## Problem

The repository did not provide uniquely identifiable provenance rules for internal dependencies, and the SBOM report treated feature-specific paths too generically. That made it harder to tell which internal packages or source checkouts influenced a given shipped build.

## Approach

Replace vague `Latest` language with concrete provenance rules tied to the pinned vcpkg baseline, overlay package versions, or explicit source-build commit/tag capture requirements. Then update the SBOM dependency report so default, vcpkg feature, and CMake-only optional paths are distinguishable.

## Main Changes

- Updated `docs/SOUP.md` to replace `Latest` internal dependency references with explicit provenance rules for `common_system`, `thread_system`, `logger_system`, and `network_system`.
- Aligned SOUP sections with actual build boundaries: default dependencies, `logging` feature, `grpc` feature, and the CMake-only `MONITORING_WITH_NETWORK_SYSTEM` path.
- Updated `README.md` requirements and ecosystem integration guidance to describe version/provenance expectations instead of `latest`.
- Expanded `LICENSE-THIRD-PARTY` to record provenance rules for internal dependencies and the optional `network_system` path.
- Added `scripts/ci/generate_dependency_report.py` and wired it into `.github/workflows/sbom.yml` so SBOM artifacts now distinguish default dependencies, vcpkg feature paths, and CMake-only optional paths.

## Verification

- `python3 scripts/ci/generate_dependency_report.py`
- `python3 -m py_compile scripts/ci/generate_dependency_report.py`
- `rg -n "latest|Latest" README.md docs/SOUP.md LICENSE-THIRD-PARTY scripts/ci/generate_dependency_report.py`

## Remaining Risks / Follow-up

- Other documentation files outside the core legal/SOUP/README surface still contain older `latest` wording and were not changed in this issue.
- `network_system` remains source-resolved rather than manifest-pinned, so release engineering still needs to capture the exact git tag or commit SHA whenever that path is enabled.

Closes #507