### PR TITLE
chore(deps): update common_system vcpkg port SHA512 for v0.2.0

### DIFF
--- a/vcpkg-ports/kcenon-common-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-common-system/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcenon/common_system
     REF "${VERSION}"
-    SHA512 0  # TODO: Update with actual SHA512 hash after release
+    SHA512 7385ba3a073fea06604f71a7ffc016425408c768444cec2ec897537411926a7e1fad99f7215e6724b3668a6e227f0716dbdcdda462764f5c4e52709087751e26
     HEAD_REF main
 )
 


### PR DESCRIPTION
## Summary

- Replace placeholder SHA512 (`0`) with actual hash from `v0.2.0` release archive
- Enables proper `vcpkg install kcenon-common-system` with the overlay port

SHA512 obtained from: `curl -sL https://github.com/kcenon/common_system/archive/refs/tags/v0.2.0.tar.gz | sha512sum`

Related: kcenon/common_system#428, kcenon/common_system#401

## Test plan

- [x] Verify `vcpkg install kcenon-common-system --overlay-ports=vcpkg-ports` succeeds
- [x] Confirm SHA512 matches the v0.2.0 archive