### PR TITLE
chore(deps): update kcenon-thread-system port to v0.3.0 with valid SHA512

### DIFF
--- a/vcpkg-ports/kcenon-thread-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-thread-system/portfile.cmake
@@ -4,8 +4,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcenon/thread_system
-    REF 80242646537034754121657f18649939cecd77c6
-    SHA512 0  # TODO: Update with actual SHA512 hash
+    REF v0.3.0
+    SHA512 7a3336340ec24230d8a5c94c7a0c0c9b671f0e9c9f2e88f9d122f86799afa3c6af7a271eb8d92d5c1d419e7d0a0a0a936c18ef7af845f737816f6800f9f9c4a3
     HEAD_REF main
 )
 


### PR DESCRIPTION
## What

Update the vcpkg overlay port for `kcenon/thread_system` from a raw commit SHA to the stable `v0.3.0` release tag with the correct SHA512 hash.

### Change Type
- [x] Chore (dependency update)

## Why

### Related Issues
- Closes kcenon/thread_system#570

### Motivation
The existing portfile used a bare commit SHA as `REF` and a placeholder `SHA512 0`, which:
1. Blocks actual `vcpkg install` execution (placeholder hash fails validation)
2. Fails vcpkg PR review checklist c000005 (requires versioned archives — tags, not commit SHAs)
3. Breaks IEC 62304 SOUP traceability (unpinned, non-auditable reference)

## Where

### Files Changed

| File | Change |
|------|--------|
| `vcpkg-ports/kcenon-thread-system/portfile.cmake` | REF: commit SHA → `v0.3.0`; SHA512: `0` → actual hash |

## How

### Implementation Details

The `v0.3.0` tag was created in `kcenon/thread_system` after merging:
- [#571](https://github.com/kcenon/thread_system/pull/571): `fix(build)` — link `common_system` target for vcpkg `find_package` path
- [#572](https://github.com/kcenon/thread_system/pull/572): `chore(release)` — bump version to 0.3.0
- [#573](https://github.com/kcenon/thread_system/pull/573): `fix(ci)` — pin OSV scanner and grant docs permissions

SHA512 was computed by downloading the GitHub-generated source archive and running `sha512sum`:
```
curl -sL https://github.com/kcenon/thread_system/archive/refs/tags/v0.3.0.tar.gz | sha512sum
```

### Testing Done
- [x] SHA512 computed from actual release archive
- [x] REF verified against existing `v0.3.0` tag at `kcenon/thread_system`
- [ ] Full `vcpkg install --overlay-ports` validation (requires vcpkg environment)

### Breaking Changes
None — overlay port only. Downstream builds using this port will now install from a stable tagged release instead of a floating commit reference.