### PR TITLE
chore(vcpkg): update monitoring_system port to v0.1.0 with valid SHA512

### DIFF
--- a/vcpkg-ports/kcenon-monitoring-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-monitoring-system/portfile.cmake
@@ -4,8 +4,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcenon/monitoring_system
-    REF 2d8802c2980b6b99acffc812fc588c377bedefa4
-    SHA512 0  # TODO: Update with actual SHA512 hash
+    REF v0.1.0
+    SHA512 65e6e23cfa8ae49b653230d13ff111c393eda35bcd45802e0b8318028fc36aeed9bf92300d5c7a8b41618e0da7689852930ad3d2ea0a82011ef45973de1d03e4
     HEAD_REF main
 )
 


### PR DESCRIPTION
Closes #509

## Summary
- Created annotated git tag v0.1.0 on main branch
- Created GitHub Release with auto-generated changelog
- Updated portfile.cmake REF from commit SHA to stable release tag v0.1.0
- Replaced placeholder SHA512 hash (0) with actual archive hash

## Context
- Blocked by thread_system#569 (CMake linking fix) -- now resolved
- Related: #279 (vcpkg registry tracking), #284 (overlay port)

## Test Plan
- [ ] Verify v0.1.0 tag exists: git tag -l v0.1.0
- [ ] Verify GitHub Release exists
- [ ] Verify portfile REF points to tag, not commit SHA
- [ ] Verify SHA512 matches downloaded archive