### PR TITLE
feat(deps): switch to kcenon/vcpkg-registry for ecosystem packages

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -4,7 +4,14 @@
     "kind": "builtin",
     "baseline": "c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d"
   },
-  "overlay-ports": [
-    "./vcpkg-ports"
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/kcenon/vcpkg-registry.git",
+      "baseline": "c144e46f9efdd991b55679bbe402784d9271bce2",
+      "packages": [
+        "kcenon-*"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Closes #510

## Summary

- Created `kcenon/vcpkg-registry` repository with port definitions for all 8 ecosystem packages
- Switched `vcpkg-configuration.json` from `overlay-ports` to git-based registry reference
- Registry includes version database (baseline.json + per-port version files) and CI validation

## Registry Contents

| Package | Version | Source |
|---------|---------|--------|
| kcenon-common-system | 0.2.0 | Migrated from vcpkg-ports/ |
| kcenon-thread-system | 0.3.0 | Migrated from vcpkg-ports/ |
| kcenon-logger-system | 0.1.1 | Migrated from vcpkg-ports/ |
| kcenon-container-system | 0.1.0 | Migrated from vcpkg-ports/ |
| kcenon-monitoring-system | 0.1.0 | Migrated from vcpkg-ports/ |
| kcenon-database-system | 0.1.0 | New port |
| kcenon-network-system | 0.1.0 | New port |
| kcenon-pacs-system | 0.1.0 | New port |

## Test Plan

- [ ] Verify `vcpkg install kcenon-monitoring-system` resolves via the new registry
- [ ] Verify CI validation workflow passes on the registry repo
- [ ] Verify existing CMake builds work with registry-based resolution