### PR TITLE
fix(ci): pin trivy-action to v0.35.0 and inline Doxygen workflow

### DIFF
--- a/.github/workflows/build-Doxygen.yaml
+++ b/.github/workflows/build-Doxygen.yaml
@@ -7,9 +7,43 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
-  docs:
-    uses: kcenon/common_system/.github/workflows/doxygen.yml@main
-    with:
-      checkout-common-system: true
-    secrets: inherit
+  generate-and-deploy:
+    if: github.ref != 'refs/heads/gh-pages'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 1
+
+      - name: Checkout common_system dependency
+        uses: actions/checkout@v4
+        with:
+          repository: kcenon/common_system
+          path: common_system
+
+      - name: Install Doxygen and Graphviz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz
+
+      - name: Generate documentation
+        run: doxygen Doxyfile
+
+      - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./documents/html
+          force_orphan: true
+          enable_jekyll: false
+          commit_message: 'docs(gh-pages): update API documentation [skip ci]'
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -34,7 +34,7 @@ jobs:
     # Trivy filesystem scan — detects vulnerabilities in source code,
     # configuration files, and any lock files present.
     - name: Trivy filesystem scan
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.35.0
       with:
         scan-type: 'fs'
         scan-ref: '.'

--- a/.github/workflows/dependency-security-scan.yml
+++ b/.github/workflows/dependency-security-scan.yml
@@ -34,7 +34,7 @@ jobs:
     # Trivy filesystem scan — detects vulnerabilities in source code,
     # configuration files, and any lock files present.
     - name: Trivy filesystem scan
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.35.0
       with:
         scan-type: 'fs'
         scan-ref: '.'


### PR DESCRIPTION
## Summary

- Pin `aquasecurity/trivy-action` from `@master` to `@0.35.0` in both `cve-scan.yml` and `dependency-security-scan.yml` to prevent transient 401 download failures
- Inline `build-Doxygen.yaml` workflow instead of calling cross-repo reusable workflow from `kcenon/common_system` — the reusable workflow call has been failing with `startup_failure` on every run (50+ consecutive failures)

## Root Cause Analysis

### CVE Security Scan (cve-scan.yml)
- `aquasecurity/trivy-action@master` caused intermittent 401 Unauthorized errors when GitHub failed to download the action archive
- Pinning to a tagged release (`@0.35.0`) uses a stable, cached reference

### Generate-Documentation (build-Doxygen.yaml)
- Cross-repo reusable workflow call (`kcenon/common_system/.github/workflows/doxygen.yml@main`) consistently failed with `startup_failure` (no jobs created)
- Likely caused by GitHub Actions settings restricting external reusable workflow calls
- Fix: inline the workflow steps directly, removing the cross-repo dependency

## Test Plan

- [x] CVE Security Scan completes successfully (both cve-scan.yml and dependency-security-scan.yml)
- [x] Generate-Documentation workflow starts and runs (no longer startup_failure)
- [x] All other CI checks remain green