### PR TITLE
chore(deps): add vcpkg build chain validation infrastructure

### DIFF
--- a/.github/workflows/validate-vcpkg-chain.yml
+++ b/.github/workflows/validate-vcpkg-chain.yml
@@ -1,0 +1,77 @@
+name: Validate vcpkg Build Chain
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'vcpkg-ports/**'
+      - 'vcpkg.json'
+      - 'vcpkg-configuration.json'
+      - 'integration_tests/vcpkg_consumer/**'
+      - 'scripts/validate_vcpkg_chain.sh'
+      - '.github/workflows/validate-vcpkg-chain.yml'
+
+jobs:
+  validate:
+    name: ${{ matrix.os }} / ${{ matrix.triplet }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            triplet: x64-linux
+          - os: macos-14
+            triplet: arm64-osx
+          - os: windows-2022
+            triplet: x64-windows
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d
+
+      - name: Install GCC 13 (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-13 g++-13
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-13 100
+
+      - name: Run validation script
+        shell: bash
+        run: |
+          chmod +x scripts/validate_vcpkg_chain.sh
+          scripts/validate_vcpkg_chain.sh \
+            --vcpkg-root "$VCPKG_ROOT" \
+            --triplet ${{ matrix.triplet }} \
+            --clean \
+            --json > validation_results.json 2>validation_stderr.log || true
+
+          echo "=== Validation Results ==="
+          cat validation_results.json
+          echo ""
+          echo "=== Stderr ==="
+          cat validation_stderr.log || true
+
+      - name: Upload validation results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vcpkg-validation-${{ matrix.triplet }}
+          path: |
+            validation_results.json
+            validation_stderr.log
+            build_vcpkg_validation/vcpkg_install.log
+            build_vcpkg_validation/cmake_configure.log
+            build_vcpkg_validation/cmake_build.log
+          retention-days: 30

--- a/integration_tests/vcpkg_consumer/CMakeLists.txt
+++ b/integration_tests/vcpkg_consumer/CMakeLists.txt
@@ -1,0 +1,151 @@
+cmake_minimum_required(VERSION 3.20)
+project(vcpkg_chain_consumer LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Track which ports are found
+set(FOUND_PORTS "")
+set(MISSING_PORTS "")
+
+# ─── Tier 0: Foundation ──────────────────────────────────────────────────────
+
+find_package(common_system CONFIG REQUIRED)
+message(STATUS "Found common_system: ${common_system_DIR}")
+list(APPEND FOUND_PORTS "common_system")
+
+# ─── Tier 1: Threading & Containers ──────────────────────────────────────────
+
+find_package(thread_system CONFIG)
+if(thread_system_FOUND)
+    message(STATUS "Found thread_system: ${thread_system_DIR}")
+    list(APPEND FOUND_PORTS "thread_system")
+else()
+    message(WARNING "thread_system not found - skipping")
+    list(APPEND MISSING_PORTS "thread_system")
+endif()
+
+find_package(ContainerSystem CONFIG)
+if(ContainerSystem_FOUND)
+    message(STATUS "Found ContainerSystem: ${ContainerSystem_DIR}")
+    list(APPEND FOUND_PORTS "ContainerSystem")
+else()
+    message(WARNING "ContainerSystem not found - skipping")
+    list(APPEND MISSING_PORTS "ContainerSystem")
+endif()
+
+# ─── Tier 2: Logging ─────────────────────────────────────────────────────────
+
+find_package(LoggerSystem CONFIG)
+if(LoggerSystem_FOUND)
+    message(STATUS "Found LoggerSystem: ${LoggerSystem_DIR}")
+    list(APPEND FOUND_PORTS "LoggerSystem")
+else()
+    message(WARNING "LoggerSystem not found - skipping")
+    list(APPEND MISSING_PORTS "LoggerSystem")
+endif()
+
+# ─── Tier 3: Monitoring & Database ───────────────────────────────────────────
+
+find_package(monitoring_system CONFIG)
+if(monitoring_system_FOUND)
+    message(STATUS "Found monitoring_system: ${monitoring_system_DIR}")
+    list(APPEND FOUND_PORTS "monitoring_system")
+else()
+    message(WARNING "monitoring_system not found - skipping")
+    list(APPEND MISSING_PORTS "monitoring_system")
+endif()
+
+find_package(database_system CONFIG)
+if(database_system_FOUND)
+    message(STATUS "Found database_system: ${database_system_DIR}")
+    list(APPEND FOUND_PORTS "database_system")
+else()
+    message(WARNING "database_system not found - skipping")
+    list(APPEND MISSING_PORTS "database_system")
+endif()
+
+# ─── Tier 4: Networking ──────────────────────────────────────────────────────
+
+find_package(NetworkSystem CONFIG)
+if(NetworkSystem_FOUND)
+    message(STATUS "Found NetworkSystem: ${NetworkSystem_DIR}")
+    list(APPEND FOUND_PORTS "NetworkSystem")
+else()
+    message(WARNING "NetworkSystem not found - skipping")
+    list(APPEND MISSING_PORTS "NetworkSystem")
+endif()
+
+# ─── Tier 5: PACS ────────────────────────────────────────────────────────────
+
+find_package(pacs_system CONFIG)
+if(pacs_system_FOUND)
+    message(STATUS "Found pacs_system: ${pacs_system_DIR}")
+    list(APPEND FOUND_PORTS "pacs_system")
+else()
+    message(WARNING "pacs_system not found - skipping")
+    list(APPEND MISSING_PORTS "pacs_system")
+endif()
+
+# ─── Test Consumer Binary ────────────────────────────────────────────────────
+
+add_executable(vcpkg_chain_consumer main.cpp)
+
+# Always link common_system (required)
+if(TARGET kcenon::common_system)
+    target_link_libraries(vcpkg_chain_consumer PRIVATE kcenon::common_system)
+    target_compile_definitions(vcpkg_chain_consumer PRIVATE HAS_COMMON_SYSTEM)
+endif()
+
+# Conditionally link available ports (using actual exported target names)
+if(TARGET thread_system::ThreadSystem)
+    target_link_libraries(vcpkg_chain_consumer PRIVATE thread_system::ThreadSystem)
+    target_compile_definitions(vcpkg_chain_consumer PRIVATE HAS_THREAD_SYSTEM)
+endif()
+
+if(TARGET ContainerSystem::container)
+    target_link_libraries(vcpkg_chain_consumer PRIVATE ContainerSystem::container)
+    target_compile_definitions(vcpkg_chain_consumer PRIVATE HAS_CONTAINER_SYSTEM)
+endif()
+
+if(TARGET LoggerSystem)
+    target_link_libraries(vcpkg_chain_consumer PRIVATE LoggerSystem)
+    target_compile_definitions(vcpkg_chain_consumer PRIVATE HAS_LOGGER_SYSTEM)
+endif()
+
+if(TARGET monitoring_system)
+    target_link_libraries(vcpkg_chain_consumer PRIVATE monitoring_system)
+    target_compile_definitions(vcpkg_chain_consumer PRIVATE HAS_MONITORING_SYSTEM)
+endif()
+
+if(TARGET database)
+    target_link_libraries(vcpkg_chain_consumer PRIVATE database)
+    target_compile_definitions(vcpkg_chain_consumer PRIVATE HAS_DATABASE_SYSTEM)
+elseif(TARGET DatabaseSystem::database)
+    target_link_libraries(vcpkg_chain_consumer PRIVATE DatabaseSystem::database)
+    target_compile_definitions(vcpkg_chain_consumer PRIVATE HAS_DATABASE_SYSTEM)
+endif()
+
+if(TARGET NetworkSystem)
+    target_link_libraries(vcpkg_chain_consumer PRIVATE NetworkSystem)
+    target_compile_definitions(vcpkg_chain_consumer PRIVATE HAS_NETWORK_SYSTEM)
+endif()
+
+if(TARGET pacs_system)
+    target_link_libraries(vcpkg_chain_consumer PRIVATE pacs_system)
+    target_compile_definitions(vcpkg_chain_consumer PRIVATE HAS_PACS_SYSTEM)
+endif()
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+
+list(LENGTH FOUND_PORTS _found_count)
+list(LENGTH MISSING_PORTS _missing_count)
+
+message(STATUS "")
+message(STATUS "vcpkg chain consumer configuration:")
+message(STATUS "  Found:   ${_found_count} ports (${FOUND_PORTS})")
+if(_missing_count GREATER 0)
+    message(STATUS "  Missing: ${_missing_count} ports (${MISSING_PORTS})")
+endif()
+message(STATUS "")

--- a/integration_tests/vcpkg_consumer/main.cpp
+++ b/integration_tests/vcpkg_consumer/main.cpp
@@ -1,0 +1,139 @@
+/**
+ * @file main.cpp
+ * @brief Minimal test consumer for kcenon Tier 0-5 vcpkg build chain validation
+ *
+ * This program verifies that all 8 kcenon ecosystem libraries can be found,
+ * included, and linked in a single consumer project. It does not exercise
+ * runtime functionality — it validates build chain integrity only.
+ *
+ * Ports are conditionally included via HAS_*_SYSTEM compile definitions
+ * set by CMakeLists.txt based on which ports were found.
+ */
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+// Tier 0: common_system (always required)
+#ifdef HAS_COMMON_SYSTEM
+#include <kcenon/common/common.h>
+#endif
+
+// Tier 1: thread_system (optional)
+#ifdef HAS_THREAD_SYSTEM
+#include <kcenon/thread/core/thread_pool.h>
+#endif
+
+// Tier 1: container_system (optional)
+#ifdef HAS_CONTAINER_SYSTEM
+#include <container.h>
+#endif
+
+// Tier 2: logger_system (optional)
+#ifdef HAS_LOGGER_SYSTEM
+#include <kcenon/logger/core/logger.h>
+#endif
+
+// Tier 3: monitoring_system (optional)
+#ifdef HAS_MONITORING_SYSTEM
+#include <kcenon/monitoring/core/metrics_registry.h>
+#endif
+
+// Tier 3: database_system (optional)
+#ifdef HAS_DATABASE_SYSTEM
+#include <kcenon/database/database_manager.h>
+#endif
+
+// Tier 4: network_system (optional)
+#ifdef HAS_NETWORK_SYSTEM
+#include <kcenon/network/core/connection.h>
+#endif
+
+// Tier 5: pacs_system (optional)
+#ifdef HAS_PACS_SYSTEM
+#include <pacs/core/dicom_types.h>
+#endif
+
+int main()
+{
+    std::cout << "=== kcenon vcpkg build chain validation ===" << std::endl;
+
+    int total = 0;
+    int found = 0;
+
+    auto check = [&](const char* name, bool available) {
+        total++;
+        if (available)
+        {
+            found++;
+            std::cout << "  [OK]   " << name << std::endl;
+        }
+        else
+        {
+            std::cout << "  [SKIP] " << name << std::endl;
+        }
+    };
+
+#ifdef HAS_COMMON_SYSTEM
+    check("kcenon-common-system     (Tier 0)", true);
+#else
+    check("kcenon-common-system     (Tier 0)", false);
+#endif
+
+#ifdef HAS_THREAD_SYSTEM
+    check("kcenon-thread-system     (Tier 1)", true);
+#else
+    check("kcenon-thread-system     (Tier 1)", false);
+#endif
+
+#ifdef HAS_CONTAINER_SYSTEM
+    check("kcenon-container-system  (Tier 1)", true);
+#else
+    check("kcenon-container-system  (Tier 1)", false);
+#endif
+
+#ifdef HAS_LOGGER_SYSTEM
+    check("kcenon-logger-system     (Tier 2)", true);
+#else
+    check("kcenon-logger-system     (Tier 2)", false);
+#endif
+
+#ifdef HAS_MONITORING_SYSTEM
+    check("kcenon-monitoring-system (Tier 3)", true);
+#else
+    check("kcenon-monitoring-system (Tier 3)", false);
+#endif
+
+#ifdef HAS_DATABASE_SYSTEM
+    check("kcenon-database-system   (Tier 3)", true);
+#else
+    check("kcenon-database-system   (Tier 3)", false);
+#endif
+
+#ifdef HAS_NETWORK_SYSTEM
+    check("kcenon-network-system    (Tier 4)", true);
+#else
+    check("kcenon-network-system    (Tier 4)", false);
+#endif
+
+#ifdef HAS_PACS_SYSTEM
+    check("kcenon-pacs-system       (Tier 5)", true);
+#else
+    check("kcenon-pacs-system       (Tier 5)", false);
+#endif
+
+    std::cout << std::endl;
+    std::cout << found << "/" << total << " ports validated." << std::endl;
+
+    if (found == total)
+    {
+        std::cout << "Build chain validation PASSED." << std::endl;
+        return EXIT_SUCCESS;
+    }
+    else
+    {
+        std::cout << "Build chain validation PARTIAL." << std::endl;
+        return (found > 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+    }
+}

--- a/scripts/validate_vcpkg_chain.sh
+++ b/scripts/validate_vcpkg_chain.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+# validate_vcpkg_chain.sh - End-to-end validation of the kcenon Tier 0-5 vcpkg build chain
+#
+# Usage:
+#   ./scripts/validate_vcpkg_chain.sh [OPTIONS]
+#
+# Options:
+#   --vcpkg-root <path>   Path to vcpkg installation (default: auto-detect)
+#   --triplet <triplet>   Target triplet (default: auto-detect from platform)
+#   --registry <path>     Path to local vcpkg-registry clone (optional, uses remote by default)
+#   --skip-build          Skip test consumer build (install-only validation)
+#   --clean               Remove previous validation artifacts before starting
+#   --json                Output results as JSON
+#   --help                Show this help message
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CONSUMER_DIR="${PROJECT_ROOT}/integration_tests/vcpkg_consumer"
+BUILD_DIR="${PROJECT_ROOT}/build_vcpkg_validation"
+
+# Defaults
+VCPKG_ROOT=""
+TRIPLET=""
+REGISTRY_PATH=""
+SKIP_BUILD=false
+CLEAN=false
+JSON_OUTPUT=false
+
+# Port installation order (dependency-ordered, parallel index arrays for results)
+PORTS=(
+    "kcenon-common-system"
+    "kcenon-thread-system"
+    "kcenon-container-system"
+    "kcenon-logger-system"
+    "kcenon-monitoring-system"
+    "kcenon-database-system"
+    "kcenon-network-system"
+    "kcenon-pacs-system"
+)
+PORT_COUNT=${#PORTS[@]}
+
+# Results: parallel arrays indexed 0..7 matching PORTS
+INSTALL_STATUS=()
+FIND_STATUS=()
+for (( i=0; i<PORT_COUNT; i++ )); do
+    INSTALL_STATUS+=("unknown")
+    FIND_STATUS+=("skipped")
+done
+CONSUMER_BUILD_RESULT="skipped"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()   { [[ "$JSON_OUTPUT" == true ]] || echo -e "${BLUE}[INFO]${NC} $*"; }
+log_ok()     { [[ "$JSON_OUTPUT" == true ]] || echo -e "${GREEN}[PASS]${NC} $*"; }
+log_fail()   { [[ "$JSON_OUTPUT" == true ]] || echo -e "${RED}[FAIL]${NC} $*"; }
+log_warn()   { [[ "$JSON_OUTPUT" == true ]] || echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_header() { [[ "$JSON_OUTPUT" == true ]] || echo -e "\n${BLUE}=== $* ===${NC}"; }
+
+usage() {
+    head -17 "$0" | tail -15 | sed 's/^# \{0,1\}//'
+    exit 0
+}
+
+# Map port name to its index in PORTS array
+port_index() {
+    local name="$1"
+    for (( i=0; i<PORT_COUNT; i++ )); do
+        if [[ "${PORTS[$i]}" == "$name" ]]; then
+            echo "$i"
+            return
+        fi
+    done
+    echo "-1"
+}
+
+# Map port name to CMake find_package name
+port_to_cmake_pkg() {
+    case "$1" in
+        kcenon-common-system)     echo "common_system" ;;
+        kcenon-thread-system)     echo "thread_system" ;;
+        kcenon-container-system)  echo "ContainerSystem" ;;
+        kcenon-logger-system)     echo "LoggerSystem" ;;
+        kcenon-monitoring-system) echo "monitoring_system" ;;
+        kcenon-database-system)   echo "database_system" ;;
+        kcenon-network-system)    echo "NetworkSystem" ;;
+        kcenon-pacs-system)       echo "pacs_system" ;;
+    esac
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --vcpkg-root)  VCPKG_ROOT="$2"; shift 2 ;;
+        --triplet)     TRIPLET="$2"; shift 2 ;;
+        --registry)    REGISTRY_PATH="$2"; shift 2 ;;
+        --skip-build)  SKIP_BUILD=true; shift ;;
+        --clean)       CLEAN=true; shift ;;
+        --json)        JSON_OUTPUT=true; shift ;;
+        --help|-h)     usage ;;
+        *)             echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+detect_vcpkg() {
+    if [[ -n "$VCPKG_ROOT" ]]; then
+        if [[ ! -x "${VCPKG_ROOT}/vcpkg" ]]; then
+            echo "Error: vcpkg not found at ${VCPKG_ROOT}/vcpkg" >&2
+            exit 1
+        fi
+        return
+    fi
+
+    local candidates=(
+        "${PROJECT_ROOT}/../vcpkg"
+        "${HOME}/vcpkg"
+        "/usr/local/vcpkg"
+    )
+
+    for dir in "${candidates[@]}"; do
+        if [[ -x "${dir}/vcpkg" ]]; then
+            VCPKG_ROOT="$(cd "$dir" && pwd)"
+            log_info "Auto-detected vcpkg at: ${VCPKG_ROOT}"
+            return
+        fi
+    done
+
+    if command -v vcpkg &>/dev/null; then
+        VCPKG_ROOT="$(dirname "$(command -v vcpkg)")"
+        log_info "Found vcpkg in PATH: ${VCPKG_ROOT}"
+        return
+    fi
+
+    echo "Error: Cannot find vcpkg. Use --vcpkg-root to specify." >&2
+    exit 1
+}
+
+detect_triplet() {
+    if [[ -n "$TRIPLET" ]]; then
+        return
+    fi
+
+    local arch os
+    arch="$(uname -m)"
+    os="$(uname -s)"
+
+    case "${os}" in
+        Darwin)
+            case "${arch}" in
+                arm64)  TRIPLET="arm64-osx" ;;
+                x86_64) TRIPLET="x64-osx" ;;
+            esac
+            ;;
+        Linux)   TRIPLET="x64-linux" ;;
+        MINGW*|MSYS*|CYGWIN*) TRIPLET="x64-windows" ;;
+    esac
+
+    if [[ -z "$TRIPLET" ]]; then
+        echo "Error: Cannot detect triplet for ${os}/${arch}. Use --triplet." >&2
+        exit 1
+    fi
+
+    log_info "Auto-detected triplet: ${TRIPLET}"
+}
+
+check_prerequisites() {
+    log_header "Checking Prerequisites"
+
+    local missing=()
+    command -v cmake &>/dev/null || missing+=("cmake")
+    command -v git &>/dev/null   || missing+=("git")
+
+    if ! command -v c++ &>/dev/null && ! command -v g++ &>/dev/null && ! command -v clang++ &>/dev/null; then
+        missing+=("C++ compiler")
+    fi
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "Error: Missing prerequisites: ${missing[*]}" >&2
+        exit 1
+    fi
+
+    log_ok "All prerequisites found"
+    log_info "vcpkg: ${VCPKG_ROOT}/vcpkg"
+    log_info "triplet: ${TRIPLET}"
+    log_info "cmake: $(cmake --version | head -1)"
+}
+
+setup_validation_dir() {
+    log_header "Setting Up Validation Environment"
+
+    if [[ "$CLEAN" == true ]] && [[ -d "$BUILD_DIR" ]]; then
+        log_info "Cleaning previous build artifacts..."
+        rm -rf "$BUILD_DIR"
+    fi
+
+    mkdir -p "$BUILD_DIR"
+
+    # Manifest listing all 8 ports
+    cat > "${BUILD_DIR}/vcpkg.json" << 'MANIFEST'
+{
+  "name": "vcpkg-chain-validation",
+  "version-string": "0.0.1",
+  "description": "End-to-end validation of kcenon Tier 0-5 build chain",
+  "dependencies": [
+    "kcenon-common-system",
+    "kcenon-thread-system",
+    "kcenon-container-system",
+    "kcenon-logger-system",
+    "kcenon-monitoring-system",
+    "kcenon-database-system",
+    "kcenon-network-system",
+    "kcenon-pacs-system"
+  ]
+}
+MANIFEST
+
+    # Registry configuration
+    if [[ -n "$REGISTRY_PATH" ]]; then
+        local abs_registry baseline
+        abs_registry="$(cd "$REGISTRY_PATH" && pwd)"
+        baseline="$(cd "$abs_registry" && git rev-parse HEAD)"
+
+        cat > "${BUILD_DIR}/vcpkg-configuration.json" << REGCONFIG
+{
+  "default-registry": {
+    "kind": "builtin",
+    "baseline": "c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d"
+  },
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "${abs_registry}",
+      "baseline": "${baseline}",
+      "packages": ["kcenon-*"]
+    }
+  ]
+}
+REGCONFIG
+    else
+        cp "${PROJECT_ROOT}/vcpkg-configuration.json" "${BUILD_DIR}/vcpkg-configuration.json"
+    fi
+
+    log_ok "Validation directory ready: ${BUILD_DIR}"
+}
+
+install_ports() {
+    log_header "Installing Ports (Manifest Mode)"
+    log_info "Installing all 8 ports via vcpkg manifest..."
+
+    local install_log="${BUILD_DIR}/vcpkg_install.log"
+    local install_ok=true
+
+    if "${VCPKG_ROOT}/vcpkg" install \
+        --triplet "${TRIPLET}" \
+        --x-manifest-root="${BUILD_DIR}" \
+        --x-install-root="${BUILD_DIR}/vcpkg_installed" \
+        2>&1 | tee "$install_log"; then
+        log_ok "vcpkg install completed successfully"
+    else
+        log_fail "vcpkg install failed. See ${install_log}"
+        install_ok=false
+    fi
+
+    # Verify each port
+    for (( i=0; i<PORT_COUNT; i++ )); do
+        local port="${PORTS[$i]}"
+        local status_file="${BUILD_DIR}/vcpkg_installed/vcpkg/status"
+        local info_dir="${BUILD_DIR}/vcpkg_installed/vcpkg/info"
+
+        if [[ -f "$status_file" ]] && grep -q "Package: ${port}" "$status_file"; then
+            INSTALL_STATUS[$i]="pass"
+            log_ok "  ${port}: installed"
+        elif [[ -d "$info_dir" ]] && ls "${info_dir}/${port}"_* &>/dev/null 2>&1; then
+            INSTALL_STATUS[$i]="pass"
+            log_ok "  ${port}: installed"
+        elif [[ "$install_ok" == false ]] && grep -q "Error:.*${port}" "$install_log" 2>/dev/null; then
+            INSTALL_STATUS[$i]="fail"
+            log_fail "  ${port}: build error"
+        else
+            INSTALL_STATUS[$i]="unknown"
+            log_warn "  ${port}: status unknown"
+        fi
+    done
+}
+
+build_consumer() {
+    if [[ "$SKIP_BUILD" == true ]]; then
+        log_info "Skipping test consumer build (--skip-build)"
+        CONSUMER_BUILD_RESULT="skipped"
+        return
+    fi
+
+    log_header "Building Test Consumer"
+
+    local consumer_build="${BUILD_DIR}/consumer_build"
+    mkdir -p "$consumer_build"
+
+    local cmake_log="${BUILD_DIR}/cmake_configure.log"
+    local build_log="${BUILD_DIR}/cmake_build.log"
+
+    log_info "Configuring test consumer..."
+    if cmake \
+        -S "${CONSUMER_DIR}" \
+        -B "${consumer_build}" \
+        -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+        -DVCPKG_MANIFEST_DIR="${BUILD_DIR}" \
+        -DVCPKG_INSTALLED_DIR="${BUILD_DIR}/vcpkg_installed" \
+        -DVCPKG_TARGET_TRIPLET="${TRIPLET}" \
+        -DCMAKE_CXX_STANDARD=20 \
+        2>&1 | tee "$cmake_log"; then
+
+        log_ok "CMake configure succeeded"
+
+        # Check find_package results
+        for (( i=0; i<PORT_COUNT; i++ )); do
+            local port="${PORTS[$i]}"
+            local pkg_name
+            pkg_name="$(port_to_cmake_pkg "$port")"
+
+            if grep -q "Found ${pkg_name}" "$cmake_log" 2>/dev/null || \
+               grep -q "${pkg_name}_FOUND" "$cmake_log" 2>/dev/null; then
+                FIND_STATUS[$i]="pass"
+                log_ok "  find_package(${pkg_name}): found"
+            elif grep -qi "not find.*${pkg_name}\|Could NOT find ${pkg_name}" "$cmake_log" 2>/dev/null; then
+                FIND_STATUS[$i]="fail"
+                log_fail "  find_package(${pkg_name}): NOT found"
+            else
+                FIND_STATUS[$i]="unknown"
+                log_warn "  find_package(${pkg_name}): status unclear"
+            fi
+        done
+    else
+        log_fail "CMake configure failed. See ${cmake_log}"
+        CONSUMER_BUILD_RESULT="configure_failed"
+        return
+    fi
+
+    log_info "Building test consumer..."
+    if cmake --build "${consumer_build}" 2>&1 | tee "$build_log"; then
+        log_ok "Test consumer build succeeded"
+        CONSUMER_BUILD_RESULT="pass"
+    else
+        log_fail "Test consumer build failed. See ${build_log}"
+        CONSUMER_BUILD_RESULT="build_failed"
+    fi
+}
+
+report_results() {
+    if [[ "$JSON_OUTPUT" == true ]]; then
+        report_json
+        return
+    fi
+
+    log_header "Validation Results"
+
+    echo ""
+    echo "Platform: $(uname -s) $(uname -m)"
+    echo "Triplet:  ${TRIPLET}"
+    echo "vcpkg:    ${VCPKG_ROOT}"
+    echo ""
+
+    printf "%-30s %-12s %-12s\n" "Port" "Install" "find_package"
+    printf "%-30s %-12s %-12s\n" "------------------------------" "------------" "------------"
+
+    local all_pass=true
+    for (( i=0; i<PORT_COUNT; i++ )); do
+        local port="${PORTS[$i]}"
+        local ist="${INSTALL_STATUS[$i]}"
+        local fst="${FIND_STATUS[$i]}"
+
+        local id fd
+        case "$ist" in
+            pass) id="${GREEN}PASS${NC}" ;;
+            fail) id="${RED}FAIL${NC}"; all_pass=false ;;
+            *)    id="${YELLOW}UNKNOWN${NC}"; all_pass=false ;;
+        esac
+        case "$fst" in
+            pass)    fd="${GREEN}PASS${NC}" ;;
+            fail)    fd="${RED}FAIL${NC}"; all_pass=false ;;
+            skipped) fd="-" ;;
+            *)       fd="${YELLOW}UNKNOWN${NC}" ;;
+        esac
+
+        printf "%-30s %-24b %-24b\n" "$port" "$id" "$fd"
+    done
+
+    echo ""
+    case "$CONSUMER_BUILD_RESULT" in
+        pass)             echo -e "Consumer Build: ${GREEN}PASS${NC}" ;;
+        skipped)          echo -e "Consumer Build: ${YELLOW}SKIPPED${NC}" ;;
+        configure_failed) echo -e "Consumer Build: ${RED}CONFIGURE FAILED${NC}"; all_pass=false ;;
+        build_failed)     echo -e "Consumer Build: ${RED}BUILD FAILED${NC}"; all_pass=false ;;
+    esac
+
+    echo ""
+    echo "Logs: ${BUILD_DIR}/"
+
+    if [[ "$all_pass" == true ]] && [[ "$CONSUMER_BUILD_RESULT" != "skipped" ]]; then
+        echo ""
+        echo -e "${GREEN}All validations passed for ${TRIPLET}${NC}"
+        return 0
+    elif [[ "$all_pass" == true ]]; then
+        echo ""
+        echo -e "${YELLOW}Install passed; consumer build was skipped${NC}"
+        return 0
+    else
+        echo ""
+        echo -e "${RED}Some validations failed. Check logs for details.${NC}"
+        return 1
+    fi
+}
+
+report_json() {
+    echo "{"
+    echo "  \"platform\": \"$(uname -s) $(uname -m)\","
+    echo "  \"triplet\": \"${TRIPLET}\","
+    echo "  \"vcpkg_root\": \"${VCPKG_ROOT}\","
+
+    # install_results
+    echo "  \"install_results\": {"
+    for (( i=0; i<PORT_COUNT; i++ )); do
+        local comma=""
+        if (( i < PORT_COUNT - 1 )); then comma=","; fi
+        echo "    \"${PORTS[$i]}\": \"${INSTALL_STATUS[$i]}\"${comma}"
+    done
+    echo "  },"
+
+    # find_package_results
+    echo "  \"find_package_results\": {"
+    for (( i=0; i<PORT_COUNT; i++ )); do
+        local comma=""
+        if (( i < PORT_COUNT - 1 )); then comma=","; fi
+        echo "    \"${PORTS[$i]}\": \"${FIND_STATUS[$i]}\"${comma}"
+    done
+    echo "  },"
+
+    echo "  \"consumer_build\": \"${CONSUMER_BUILD_RESULT}\","
+    echo "  \"log_dir\": \"${BUILD_DIR}\""
+    echo "}"
+}
+
+main() {
+    detect_vcpkg
+    detect_triplet
+    check_prerequisites
+    setup_validation_dir
+    install_ports
+    build_consumer
+    report_results
+}
+
+main


### PR DESCRIPTION
Closes #519
Part of #511

## Summary

- Add validation script (`scripts/validate_vcpkg_chain.sh`) for end-to-end Tier 0-5 vcpkg build chain verification
- Add test consumer project (`integration_tests/vcpkg_consumer/`) that uses `find_package()` for all 8 ecosystem ports
- Add CI workflow (`.github/workflows/validate-vcpkg-chain.yml`) for cross-platform validation on x64-windows, x64-linux, arm64-osx

## Validation Findings (arm64-osx)

Initial local validation uncovered systemic cross-port integration issues:

| Port | Tier | Install | Issue |
|------|------|---------|-------|
| kcenon-common-system | 0 | PASS | Exports `kcenon::common_system` (not `kcenon::common`) |
| kcenon-thread-system | 1 | PASS | Exports `thread_system::ThreadSystem`; pkgconfig warnings |
| kcenon-container-system | 1 | PASS | Exports `ContainerSystem::container` |
| kcenon-logger-system | 2 | **FAIL** | `find_package(thread_system)` fails despite installation; FetchContent fallback fails in vcpkg sandbox |
| kcenon-database-system | 3 | **FAIL** | CMake target name mismatch: checks `common_system`/`kcenon::common` but installed target is `kcenon::common_system` |
| kcenon-monitoring-system | 3 | blocked | Blocked by logger_system failure |
| kcenon-network-system | 4 | blocked | Blocked by logger_system failure |
| kcenon-pacs-system | 5 | blocked | Blocked by network_system |

### Root Cause

The exported CMake target names from installed ports don't match what consumer ports expect. This is a systemic issue across the ecosystem that needs to be addressed in each port's CMake config before the full chain can validate.

### Filed Issues

- kcenon/database_system#432 — target name mismatch for common_system
- kcenon/logger_system#482 — thread_system find_package failure

### Sub-issues of #511

- [x] #519 — Create validation script and test consumer (this PR)
- [ ] #520 — Execute local validation and fix port issues (blocked by upstream fixes)
- [ ] #521 — CI cross-platform validation workflow (included in this PR)

## Test Plan

- [ ] CI workflow runs on all 3 platforms
- [ ] `scripts/validate_vcpkg_chain.sh --json` produces valid JSON output
- [ ] Test consumer CMakeLists.txt gracefully handles missing ports