### PR TITLE
docs: improve Doxyfile configuration and fix comment issues

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1,4 +1,5 @@
 PROJECT_NAME           = "Monitoring System"
+PROJECT_BRIEF          = "System resource monitoring with pluggable collectors and alerting"
 OUTPUT_DIRECTORY       = documents
 CREATE_SUBDIRS         = YES
 ALLOW_UNICODE_NAMES    = NO
@@ -85,7 +86,7 @@ QUIET                  = NO
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
-WARN_NO_PARAMDOC       = NO
+WARN_NO_PARAMDOC       = YES
 WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$line: $text"
 WARN_LOGFILE           =
@@ -104,25 +105,32 @@ FILE_PATTERNS          = *.c \
                          *.h \
                          *.hh \
                          *.hpp \
-                         *.tpp
+                         *.tpp \
+                         *.cppm
 RECURSIVE              = YES
-EXCLUDE                =
+EXCLUDE                = ./build \
+                         ./vcpkg \
+                         ./vcpkg_installed \
+                         ./documents
 EXCLUDE_SYMLINKS       = NO
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = */CMakeFiles/* \
+                         */.git/* \
+                         */build/*
 EXCLUDE_SYMBOLS        =
-EXAMPLE_PATH           =
-EXAMPLE_PATTERNS       = *
-EXAMPLE_RECURSIVE      = NO
+EXAMPLE_PATH           = ./examples
+EXAMPLE_PATTERNS       = *.cpp \
+                         *.h
+EXAMPLE_RECURSIVE      = YES
 IMAGE_PATH             =
 INPUT_FILTER           =
 FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = README.md
 SOURCE_BROWSER         = YES
 INLINE_SOURCES         = YES
 STRIP_CODE_COMMENTS    = YES
-REFERENCED_BY_RELATION = NO
-REFERENCES_RELATION    = NO
+REFERENCED_BY_RELATION = YES
+REFERENCES_RELATION    = YES
 REFERENCES_LINK_SOURCE = YES
 SOURCE_TOOLTIPS        = YES
 USE_HTAGS              = NO
@@ -145,7 +153,7 @@ GENERATE_HTMLHELP      = NO
 GENERATE_QHP           = NO
 GENERATE_ECLIPSEHELP   = NO
 DISABLE_INDEX          = NO
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = YES
 FULL_SIDEBAR           = NO
 ENUM_VALUES_PER_LINE   = 4
 TREEVIEW_WIDTH         = 250
@@ -168,10 +176,12 @@ GENERATE_DOCBOOK       = NO
 GENERATE_AUTOGEN_DEF   = NO
 GENERATE_PERLMOD       = NO
 ENABLE_PREPROCESSING   = YES
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = NO
 SEARCH_INCLUDES        = YES
 SKIP_FUNCTION_MACROS   = YES
+ALIASES                = "thread_safety=@par Thread Safety:^^" \
+                         "performance=@par Performance:^^"
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 EXTERNAL_PAGES         = YES
@@ -186,7 +196,7 @@ UML_LOOK               = YES
 UML_LIMIT_NUM_FIELDS   = 10
 DOT_UML_DETAILS        = NO
 DOT_WRAP_THRESHOLD     = 17
-TEMPLATE_RELATIONS     = NO
+TEMPLATE_RELATIONS     = YES
 INCLUDE_GRAPH          = YES
 INCLUDED_BY_GRAPH      = YES
 CALL_GRAPH             = YES

--- a/include/kcenon/monitoring/core/central_collector.h
+++ b/include/kcenon/monitoring/core/central_collector.h
@@ -41,6 +41,7 @@
 namespace kcenon { namespace monitoring {
 
 /**
+ * @class central_collector
  * @brief Central collector for aggregating metrics from thread-local buffers
  *
  * Receives batches of metric samples from multiple thread-local buffers and


### PR DESCRIPTION
## Summary
- Add C++20 module support, exclude patterns, README mainpage, and ALIASES for custom tags to Doxyfile
- Enable tree view navigation, cross-references, macro expansion, and template relations
- Add ALIASES for `@thread_safety` and `@performance` custom tags to render as labeled sections
- Add `@class` tag to `central_collector` documentation block

## Test plan
- [ ] Run `doxygen Doxyfile` and verify no new warnings
- [ ] Verify `@thread_safety` renders as a labeled "Thread Safety" section
- [ ] Verify tree view navigation appears in HTML output
- [ ] Verify `.cppm` files are included in documentation

Closes #526