### PR TITLE
docs: replace GIT_TAG main with tagged versions in FetchContent examples

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -275,7 +275,7 @@ include(FetchContent)
 FetchContent_Declare(
     monitoring_system
     GIT_REPOSITORY https://github.com/kcenon/monitoring_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0 # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_MakeAvailable(monitoring_system)

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ include(FetchContent)
 FetchContent_Declare(
     monitoring_system
     GIT_REPOSITORY https://github.com/kcenon/monitoring_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0 # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_MakeAvailable(monitoring_system)

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -71,7 +71,7 @@ include(FetchContent)
 FetchContent_Declare(
     monitoring_system
     GIT_REPOSITORY https://github.com/kcenon/monitoring_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0 # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_MakeAvailable(monitoring_system)

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -59,7 +59,7 @@ include(FetchContent)
 FetchContent_Declare(
     monitoring_system
     GIT_REPOSITORY https://github.com/kcenon/monitoring_system.git
-    GIT_TAG        v1.0.0  # or main for latest
+    GIT_TAG        v0.1.0 # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_MakeAvailable(monitoring_system)


### PR DESCRIPTION
## Summary

- Replace `GIT_TAG main` with `GIT_TAG v0.1.0` in all FetchContent CMake examples across documentation
- Add comment `# Pin to a specific release tag; do NOT use main` to each pinned tag
- Prevents users from copy-pasting non-reproducible build configurations

Part of kcenon/common_system#448

## Changed Files

- `README.md` - FetchContent example pinned to `v0.1.0`
- `README.kr.md` - FetchContent example pinned to `v0.1.0`
- `docs/guides/QUICK_START.md` - FetchContent example pinned to `v0.1.0` (was `v1.0.0 # or main for latest`)
- `docs/guides/QUICK_START.kr.md` - FetchContent example pinned to `v0.1.0`