### PR TITLE
chore(deps): update kcenon-container-system portfile REF to v0.1.0

### DIFF
--- a/vcpkg-ports/kcenon-container-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-container-system/portfile.cmake
@@ -4,8 +4,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcenon/container_system
-    REF 123d7db3e523167de85f707600df0884e35a871f
-    SHA512 7d9a9fd0bf89548bf4c76ac2664fb47f5541b8564637d26350deee10da2ffe20020d892d1cdb678a36af1569da4adb7db9ee6c4bda6ff891d37aa3e6dacb0dcc
+    REF v0.1.0
+    SHA512 ca2feee08c7cef41d297c49c4a4eb8559dcb4c680d42e70bc011b8928e88b82e16fab3e54f44e15e3c1e1ce0738950de9e8c55fea6d090cd8d3db628a46fb444
     HEAD_REF main
 )
 


### PR DESCRIPTION
## What

Update `kcenon-container-system` vcpkg portfile to use the stable release tag
`v0.1.0` instead of the raw commit hash.

### Change Type
- [x] Chore (dependency/configuration update)

## Why

### Problem Solved
The portfile was referencing a raw commit hash (`123d7db3e523167de85f707600df0884e35a871f`),
which lacks semantic meaning and complicates upgrade tracking. The container_system
project now has a proper `v0.1.0` release tag.

### Related Issues
- Relates to kcenon/container_system#420

## Where

### Files Changed
| File | Change |
|------|--------|
| `vcpkg-ports/kcenon-container-system/portfile.cmake` | REF: commit hash → `v0.1.0`, SHA512: recomputed |

## How

### Changes
- `REF`: `123d7db3e523167de85f707600df0884e35a871f` → `v0.1.0`
- `SHA512`: recomputed from `https://github.com/kcenon/container_system/archive/refs/tags/v0.1.0.tar.gz`

### Testing Done
- [x] SHA512 verified against downloaded tarball (`sha512sum`)
- [ ] `vcpkg install kcenon-container-system` with overlay ports (requires vcpkg environment)

## Checklist
- [x] REF updated to semantic version tag
- [x] SHA512 recomputed for tagged archive
- [x] Related issue linked