### PR TITLE
docs(deps): establish monitoring_system as canonical vcpkg port registry

### DIFF
--- a/docs/guides/PORT_MANAGEMENT.md
+++ b/docs/guides/PORT_MANAGEMENT.md
@@ -1,0 +1,205 @@
+# vcpkg Port Management
+
+This document defines the authoritative port management strategy for the kcenon
+ecosystem and serves as the definitive reference for all port-related work.
+
+## Strategy: Centralized in monitoring_system
+
+**Decision**: All vcpkg port definitions are maintained in
+`kcenon/monitoring_system/vcpkg-ports/`.
+
+This repository is the **single source of truth** for every kcenon port.
+No other repository should maintain its own copy of a port definition.
+
+### Rationale
+
+| Criterion | Outcome |
+|-----------|---------|
+| Single update location | All eight ports live in one directory |
+| Patch management | Upstream patches stored alongside port definitions |
+| CI validation | `validate-vcpkg-chain` workflow tests every port change |
+| Dependency resolution | All inter-port dependencies visible in one place |
+
+Alternative strategies were considered and rejected:
+
+- **Per-repo ports** (Option C): Stale local copies in `database_system`,
+  `network_system`, and `pacs_system` already demonstrated how quickly
+  per-repo ports fall out of sync (SHA512 placeholders, missing patches).
+- **Dedicated vcpkg-registry repo** (Option B): Adds an extra repository to
+  maintain with no benefit over the existing `kcenon/vcpkg-registry.git`
+  workflow, which is populated from monitoring_system on each release.
+
+## Port Inventory
+
+| Port | Upstream Repo | Port-Version | Patches |
+|------|--------------|-------------|---------|
+| kcenon-common-system | `kcenon/common_system` | 0 | — |
+| kcenon-thread-system | `kcenon/thread_system` | 0 | — |
+| kcenon-logger-system | `kcenon/logger_system` | 0 | fix-unified-deps-target-names |
+| kcenon-container-system | `kcenon/container_system` | 0 | — |
+| kcenon-monitoring-system | `kcenon/monitoring_system` | 0 | — |
+| kcenon-database-system | `kcenon/database_system` | 2 | fix-common-system-target |
+| kcenon-network-system | `kcenon/network_system` | 3 | fix-common-system-target |
+| kcenon-pacs-system | `kcenon/pacs_system` | 2 | fix-vcpkg-dependency-discovery |
+
+Port-version is incremented when the portfile changes but the upstream source
+does not (e.g., adding a patch or fixing a CMake option).
+
+## Port Update Procedure
+
+Follow these steps whenever an upstream repository tags a new release.
+
+### Step 1 — Determine the new commit
+
+```bash
+# Fetch the new tag SHA from GitHub
+gh release view v<NEW_VERSION> --repo kcenon/<system_name> --json tagName,targetCommitish
+```
+
+### Step 2 — Download and hash the archive
+
+```bash
+# Download the source archive vcpkg will fetch
+REPO="kcenon/<system_name>"
+REF="v<NEW_VERSION>"
+URL="https://github.com/${REPO}/archive/refs/tags/${REF}.tar.gz"
+curl -fsSL "$URL" -o /tmp/source.tar.gz
+sha512sum /tmp/source.tar.gz
+```
+
+### Step 3 — Update the portfile
+
+Edit `vcpkg-ports/kcenon-<system>-system/portfile.cmake`:
+
+```cmake
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kcenon/<system_name>
+    REF v<NEW_VERSION>          # ← update
+    SHA512 <new_sha512_hash>    # ← update
+    HEAD_REF main
+)
+```
+
+### Step 4 — Update vcpkg.json
+
+Edit `vcpkg-ports/kcenon-<system>-system/vcpkg.json`:
+
+```json
+{
+  "name": "kcenon-<system>-system",
+  "version": "<new_version>",    ← update
+  "port-version": 0,             ← reset to 0 on upstream version bump
+  ...
+}
+```
+
+> **Note**: Reset `port-version` to `0` whenever the upstream `version` field
+> changes.  Increment `port-version` only for portfile-only fixes.
+
+### Step 5 — Test locally
+
+```bash
+# Verify the port installs cleanly
+vcpkg install kcenon-<system>-system \
+  --overlay-ports=./vcpkg-ports \
+  --triplet x64-linux
+```
+
+### Step 6 — Update the vcpkg-ports/README.md version table
+
+Update the `Version` and `Port-Version` columns in
+`vcpkg-ports/README.md`.
+
+### Step 7 — Open a PR
+
+Create a PR targeting `main`.  The `validate-vcpkg-chain` CI workflow will
+automatically build and test the updated port on Ubuntu, macOS, and Windows.
+
+### Step 8 — Sync to vcpkg-registry (post-merge)
+
+After the PR merges, sync the updated port to `kcenon/vcpkg-registry.git`
+so that consumers using the remote registry receive the update:
+
+```bash
+# Copy updated port files to the vcpkg-registry checkout
+cp -r vcpkg-ports/kcenon-<system>-system/ \
+      /path/to/vcpkg-registry/ports/kcenon-<system>-system/
+
+# Update the versions database in vcpkg-registry
+# (follow vcpkg versioning documentation for baseline/versions files)
+```
+
+## Consumer Repository Setup
+
+Repositories that depend on kcenon packages should **not** maintain local
+port copies.  Instead, configure CMake to use monitoring_system's overlay:
+
+```bash
+cmake -B build \
+  -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+  -DVCPKG_OVERLAY_PORTS=/path/to/monitoring_system/vcpkg-ports
+```
+
+For CI pipelines, either:
+
+1. **Submodule**: Add `monitoring_system` as a git submodule and reference
+   `$(pwd)/monitoring_system/vcpkg-ports` as the overlay path.
+2. **Shallow clone**: Perform a sparse/shallow clone of `monitoring_system`
+   in the CI job and pass the path as an environment variable.
+3. **Remote registry**: Reference `kcenon/vcpkg-registry.git` in
+   `vcpkg-configuration.json` for stable released versions.
+
+## Stale Local Ports — Cleanup Required
+
+The following repositories previously contained local port copies that are
+now stale (outdated versions, `SHA512 0` placeholders, missing patches).
+They should be removed in favour of the canonical ports in this repository.
+
+| Repository | Stale Path | Status |
+|------------|-----------|--------|
+| `kcenon/database_system` | `vcpkg-ports/` | Needs removal (port-v1, SHA512=0) |
+| `kcenon/network_system` | `vcpkg-ports/` | Needs removal (port-v0, SHA512=0) |
+| `kcenon/pacs_system` | `vcpkg-ports/` | Needs removal (port-v0, SHA512=0) |
+
+Open a PR in each repository to delete their `vcpkg-ports/` directory and
+update their README to point to this canonical location.
+
+## Relationship with vcpkg-registry
+
+`kcenon/vcpkg-registry.git` provides a stable, versioned view of kcenon ports
+for consumers who prefer not to use overlay ports.  It is **downstream** of
+this directory: changes land here first, then propagate to the registry on
+release.
+
+```
+monitoring_system/vcpkg-ports/   ← source of truth (development)
+         │
+         │  (synced on release)
+         ▼
+kcenon/vcpkg-registry.git        ← stable registry (production consumers)
+```
+
+Do not make direct edits to `kcenon/vcpkg-registry.git` port files.
+All changes must flow through `monitoring_system/vcpkg-ports/` first.
+
+## CI Validation
+
+The `validate-vcpkg-chain` workflow (`.github/workflows/validate-vcpkg-chain.yml`)
+runs on every PR that touches:
+
+- `vcpkg-ports/**`
+- `vcpkg.json`
+- `vcpkg-configuration.json`
+- `integration_tests/vcpkg_consumer/**`
+- `scripts/validate_vcpkg_chain.sh`
+
+The workflow installs the full kcenon dependency chain via the overlay ports
+and builds the consumer integration test on three platforms.  A PR that breaks
+any port will fail this check before merge.
+
+## Related
+
+- [VCPKG_OVERLAY_PORTS.md](VCPKG_OVERLAY_PORTS.md) — installation and usage guide
+- [vcpkg-ports/README.md](../../vcpkg-ports/README.md) — port inventory
+- [#533](https://github.com/kcenon/monitoring_system/issues/533) — issue tracking this decision

--- a/docs/guides/VCPKG_OVERLAY_PORTS.md
+++ b/docs/guides/VCPKG_OVERLAY_PORTS.md
@@ -1,19 +1,28 @@
 # vcpkg Overlay Ports Guide
 
-This guide explains how to use the vcpkg overlay ports for the kcenon ecosystem packages.
+This guide explains how to use the vcpkg overlay ports provided by the
+`monitoring_system` repository, which acts as the **canonical port registry**
+for the entire kcenon ecosystem.
 
 ## Overview
 
-The `vcpkg-ports/` directory contains overlay port definitions for local testing before official vcpkg registry submission. These ports allow you to install and test the kcenon ecosystem packages locally.
+The `vcpkg-ports/` directory contains port definitions for all eight kcenon
+ecosystem packages.  These overlay ports let you build against any version of
+the kcenon libraries — including unreleased commits — without waiting for the
+official vcpkg registry to be updated.
 
 ## Available Ports
 
-| Port | Version | Description |
-|------|---------|-------------|
-| kcenon-common-system | 0.2.0 | Foundation library with Result<T> pattern and interfaces |
-| kcenon-thread-system | 0.3.0 | High-performance multithreading framework |
-| kcenon-logger-system | 0.1.0 | High-performance async logging framework |
-| kcenon-monitoring-system | 0.1.0 | Monitoring system with metrics, tracing, and container monitoring |
+| Port | Version | Port-Version | Description |
+|------|---------|-------------|-------------|
+| kcenon-common-system | 0.2.0 | 0 | Foundation library with Result\<T\> pattern and interfaces |
+| kcenon-thread-system | 0.3.0 | 0 | High-performance multithreading framework |
+| kcenon-logger-system | 0.1.2 | 0 | High-performance async logging framework |
+| kcenon-container-system | 0.1.0 | 0 | Advanced container system with thread-safe operations |
+| kcenon-monitoring-system | 0.1.0 | 0 | Monitoring system with metrics, tracing, and container monitoring |
+| kcenon-database-system | 0.1.0 | 2 | Core DAL library with multi-backend support |
+| kcenon-network-system | 0.1.0 | 3 | Async network library with TCP/UDP, HTTP/1.1, WebSocket, TLS 1.3 |
+| kcenon-pacs-system | 0.1.0 | 2 | Modern C++20 PACS implementation |
 
 ## Prerequisites
 
@@ -29,7 +38,7 @@ The `vcpkg-ports/` directory contains overlay port definitions for local testing
 # Set the overlay ports path
 export VCPKG_OVERLAY_PORTS="/path/to/monitoring_system/vcpkg-ports"
 
-# Install packages using overlay ports
+# Install individual packages
 vcpkg install kcenon-common-system --overlay-ports=./vcpkg-ports
 vcpkg install kcenon-thread-system --overlay-ports=./vcpkg-ports
 vcpkg install kcenon-logger-system --overlay-ports=./vcpkg-ports
@@ -41,7 +50,6 @@ vcpkg install kcenon-monitoring-system --overlay-ports=./vcpkg-ports
 Add to your `CMakeLists.txt`:
 
 ```cmake
-# Using vcpkg toolchain
 cmake_minimum_required(VERSION 3.20)
 project(your_project)
 
@@ -91,13 +99,27 @@ kcenon-monitoring-system
 ├── kcenon-common-system (required)
 ├── kcenon-thread-system (required)
 │   └── kcenon-common-system
-│   └── libiconv (non-Windows)
+│   └── simdutf
 ├── [logging] kcenon-logger-system
 │   ├── kcenon-common-system
 │   ├── kcenon-thread-system
 │   ├── fmt
 │   └── libiconv (non-Windows)
-└── [network] (enables HTTP metrics export)
+└── [network] kcenon-network-system
+    ├── kcenon-common-system
+    ├── kcenon-thread-system
+    ├── kcenon-logger-system
+    ├── asio
+    └── openssl
+
+kcenon-database-system
+└── kcenon-common-system
+
+kcenon-pacs-system
+├── kcenon-common-system
+├── kcenon-container-system
+│   └── kcenon-common-system
+└── kcenon-network-system
 ```
 
 ## Optional Features
@@ -115,32 +137,35 @@ vcpkg install kcenon-monitoring-system[logging] --overlay-ports=./vcpkg-ports
 vcpkg install kcenon-monitoring-system[logging,network] --overlay-ports=./vcpkg-ports
 ```
 
-## Testing Status
+## Consumer Repository Setup
 
-| Port | vcpkg Install | Build | Notes |
-|------|---------------|-------|-------|
-| kcenon-common-system | ✅ Pass | ✅ Pass | Header-only library |
-| kcenon-thread-system | ✅ Pass | ⚠️ Blocked | Upstream CMake issue (common_system linking) |
-| kcenon-logger-system | ✅ Pass | ⚠️ Blocked | Depends on thread_system fix |
-| kcenon-monitoring-system | ✅ Pass | ⚠️ Blocked | Depends on thread_system fix |
+Projects that depend on kcenon packages should reference monitoring_system's
+overlay ports rather than maintaining their own local port copies.
 
-### Known Issues
+Add the monitoring_system overlay path to your CMake configure step:
 
-The `thread_system`, `logger_system`, and `monitoring_system` builds are blocked due to an upstream CMake configuration issue:
+```bash
+cmake -B build \
+  -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+  -DVCPKG_OVERLAY_PORTS=/path/to/monitoring_system/vcpkg-ports
+```
 
-- **Problem**: `ThreadSystemDependencies.cmake` finds `common_system` via `find_package()` but doesn't link the `kcenon::common_system` target to the `ThreadSystem` library
-- **Symptom**: Build fails with "fatal error: 'kcenon/common/patterns/result.h' file not found"
-- **Solution**: Upstream repositories need to update their CMake configuration to properly link the `kcenon::common_system` target
+Or set the `VCPKG_OVERLAY_PORTS` environment variable in your CI pipeline.
+
+## Port Update Procedure
+
+See [PORT_MANAGEMENT.md](PORT_MANAGEMENT.md) for the step-by-step procedure for
+updating port definitions when a new upstream release is made.
 
 ## Notes
 
-- These overlay ports use specific commit SHA for reproducible builds
-- SHA512 hashes are placeholder values (update after release)
-- For production, wait for official vcpkg registry submission
-- Port definitions use project-specific CMake options for proper configuration
+- Port files pin specific upstream commits via SHA512 hashes for reproducible builds
+- Patches in each port directory fix upstream issues that are not yet merged upstream
+- Port-version increments indicate portfile-only fixes without upstream changes
 
 ## Related Issues
 
+- [#533](https://github.com/kcenon/monitoring_system/issues/533) - Single source of truth for vcpkg port management
 - [#279](https://github.com/kcenon/monitoring_system/issues/279) - vcpkg registry registration tracking
 - [#281](https://github.com/kcenon/monitoring_system/issues/281) - common_system port
 - [#282](https://github.com/kcenon/monitoring_system/issues/282) - thread_system port

--- a/vcpkg-ports/README.md
+++ b/vcpkg-ports/README.md
@@ -1,20 +1,21 @@
-# vcpkg Overlay Ports
+# vcpkg Overlay Ports — Canonical Registry
 
-This directory contains vcpkg overlay port definitions for the kcenon ecosystem packages.
+This directory is the **single source of truth** for vcpkg port definitions across
+the entire kcenon ecosystem.  All eight system packages are maintained here with
+real SHA512 hashes, upstream patches, and CI validation.
 
-## Purpose
+## Canonical Status
 
-These overlay ports enable local testing of the kcenon packages before official vcpkg registry submission.
-
-## Ports
-
-| Package | Version | Dependencies |
-|---------|---------|--------------|
-| kcenon-common-system | 0.2.0 | None |
-| kcenon-thread-system | 0.3.0 | common-system, libiconv |
-| kcenon-logger-system | 0.1.0 | common-system, thread-system, fmt, libiconv |
-| kcenon-monitoring-system | 0.1.0 | common-system, thread-system, [logging], [network] |
-| kcenon-container-system | 0.1.0 | common-system |
+| Package | Version | Port-Version | Patches | Dependencies |
+|---------|---------|-------------|---------|--------------|
+| kcenon-common-system | 0.2.0 | 0 | — | None |
+| kcenon-thread-system | 0.3.0 | 0 | — | common-system, simdutf |
+| kcenon-logger-system | 0.1.2 | 0 | fix-unified-deps-target-names | common-system, thread-system, fmt, libiconv |
+| kcenon-container-system | 0.1.0 | 0 | — | common-system |
+| kcenon-monitoring-system | 0.1.0 | 0 | — | common-system, thread-system |
+| kcenon-database-system | 0.1.0 | 2 | fix-common-system-target | common-system |
+| kcenon-network-system | 0.1.0 | 3 | fix-common-system-target | common-system, thread-system, logger-system, asio, openssl |
+| kcenon-pacs-system | 0.1.0 | 2 | fix-vcpkg-dependency-discovery | common-system, container-system, network-system |
 
 ## Quick Start
 
@@ -28,20 +29,36 @@ cmake -B build \
   -DVCPKG_OVERLAY_PORTS=$(pwd)/vcpkg-ports
 ```
 
+## Port Management
+
+See [PORT_MANAGEMENT.md](../docs/guides/PORT_MANAGEMENT.md) for the authoritative
+guide on updating ports, syncing to the remote registry, and onboarding consumer
+repositories.
+
 ## Documentation
 
-See [VCPKG_OVERLAY_PORTS.md](../docs/guides/VCPKG_OVERLAY_PORTS.md) for detailed usage instructions.
+See [VCPKG_OVERLAY_PORTS.md](../docs/guides/VCPKG_OVERLAY_PORTS.md) for detailed
+installation and integration instructions.
+
+## CI Validation
+
+Every change to this directory triggers the `validate-vcpkg-chain` workflow, which
+builds the consumer integration test on Ubuntu, macOS, and Windows.
 
 ## Status
 
-- [x] common_system - overlay port ready
-- [x] thread_system - overlay port ready
-- [x] logger_system - overlay port ready
-- [x] monitoring_system - overlay port ready
-- [x] container_system - overlay port ready
-- [ ] Official vcpkg registry submission - pending
+- [x] kcenon-common-system — canonical port ready, CI validated
+- [x] kcenon-thread-system — canonical port ready, CI validated
+- [x] kcenon-logger-system — canonical port ready, CI validated
+- [x] kcenon-container-system — canonical port ready, CI validated
+- [x] kcenon-monitoring-system — canonical port ready, CI validated
+- [x] kcenon-database-system — canonical port ready, CI validated
+- [x] kcenon-network-system — canonical port ready, CI validated
+- [x] kcenon-pacs-system — canonical port ready, CI validated
+- [ ] Official vcpkg registry submission — pending
 
 ## Related Issues
 
-- #279 - Main tracking issue
-- #281, #282, #283, #284 - Individual port issues
+- #533 — Establish single source of truth for vcpkg port management
+- #279 — Main tracking issue for vcpkg registry registration
+- #281, #282, #283, #284 — Individual port issues


### PR DESCRIPTION
## What

Formally documents `monitoring_system/vcpkg-ports/` as the single source of
truth for all eight kcenon vcpkg port definitions.

### Changes

| File | Change Type |
|------|------------|
| `docs/guides/PORT_MANAGEMENT.md` | New — authoritative port management strategy |
| `docs/guides/VCPKG_OVERLAY_PORTS.md` | Updated — all 8 ports, corrected notes |
| `vcpkg-ports/README.md` | Updated — canonical registry framing, full inventory |

## Why

Three locations previously held port definitions (central registry, stale local
copies in individual repos, remote registry) with no documented ownership.
Contributors had no clear guidance on which port to update and why.

- Stale `SHA512 0` placeholders in `database_system`, `network_system`, and
  `pacs_system` gave a false impression of vcpkg readiness in those repos
- `VCPKG_OVERLAY_PORTS.md` incorrectly stated "SHA512 hashes are placeholder
  values" even though the central ports have had real hashes for some time
- No documented procedure for updating ports across an upstream release

Relates to #533

## How

### Implementation

1. **PORT_MANAGEMENT.md** (new): Records the Option A decision (centralize in
   monitoring_system), documents the full port update procedure with exact
   commands, consumer repo setup options, the stale-port cleanup requirement
   for other repos, and the relationship between this directory and
   `kcenon/vcpkg-registry.git`

2. **vcpkg-ports/README.md**: Updated to list all 8 canonical ports with
   their current versions, port-versions, and patch inventory; replaces
   vague overlay-ports framing with explicit "canonical registry" language

3. **VCPKG_OVERLAY_PORTS.md**: All 8 ports in the available-ports table;
   corrected dependency graph (includes database/network/pacs); removed the
   outdated placeholder SHA512 note; added consumer repo and port update
   cross-references

### Acceptance Criteria Status

- [x] Port management strategy chosen and documented (PORT_MANAGEMENT.md)
- [x] Single authoritative location for each port definition (this repo)
- [x] Port update procedure documented (PORT_MANAGEMENT.md §Port Update Procedure)
- [x] CI validates port builds from the canonical location (existing `validate-vcpkg-chain` workflow)
- [ ] Stale local ports removed from database_system / network_system / pacs_system — tracked in PORT_MANAGEMENT.md §Stale Local Ports, requires separate PRs to those repos

### Testing

No code changes — documentation only.  The `validate-vcpkg-chain` workflow
will confirm that existing ports still build correctly.

Closes #533