### PR TITLE
chore(deps): align kcenon registry baseline and document consumer setup

### DIFF
--- a/docs/guides/PORT_MANAGEMENT.md
+++ b/docs/guides/PORT_MANAGEMENT.md
@@ -132,23 +132,43 @@ cp -r vcpkg-ports/kcenon-<system>-system/ \
 
 ## Consumer Repository Setup
 
-Repositories that depend on kcenon packages should **not** maintain local
-port copies.  Instead, configure CMake to use monitoring_system's overlay:
+Repositories that depend on kcenon packages should configure
+`vcpkg-configuration.json` to reference the remote registry:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
+  "default-registry": {
+    "kind": "builtin",
+    "baseline": "dd306f32e07d87fdb16837af64f33b6b415c770a"
+  },
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/kcenon/vcpkg-registry.git",
+      "baseline": "<latest-vcpkg-registry-commit-sha>",
+      "packages": [
+        "kcenon-*"
+      ]
+    }
+  ]
+}
+```
+
+With this configuration, `vcpkg install kcenon-<package>` resolves
+automatically without `--overlay-ports`.  All eight ecosystem repositories
+(`common_system`, `thread_system`, `logger_system`, `container_system`,
+`monitoring_system`, `database_system`, `network_system`, `pacs_system`)
+use this pattern.
+
+For development or pre-release testing, the overlay approach remains
+available:
 
 ```bash
 cmake -B build \
   -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
   -DVCPKG_OVERLAY_PORTS=/path/to/monitoring_system/vcpkg-ports
 ```
-
-For CI pipelines, either:
-
-1. **Submodule**: Add `monitoring_system` as a git submodule and reference
-   `$(pwd)/monitoring_system/vcpkg-ports` as the overlay path.
-2. **Shallow clone**: Perform a sparse/shallow clone of `monitoring_system`
-   in the CI job and pass the path as an environment variable.
-3. **Remote registry**: Reference `kcenon/vcpkg-registry.git` in
-   `vcpkg-configuration.json` for stable released versions.
 
 ## Stale Local Ports — Cleanup Required
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "c144e46f9efdd991b55679bbe402784d9271bce2",
+      "baseline": "77cc46d5ba5e2aef1581f2ec674f83e1ac906b43",
       "packages": [
         "kcenon-*"
       ]


### PR DESCRIPTION
## What

Sync the `kcenon/vcpkg-registry.git` baseline in `vcpkg-configuration.json`
to the current registry HEAD (`77cc46d5`), picking up the patch-removal
commits (#16–#18) for thread-, network-, and logger-system ports.

Update `docs/guides/PORT_MANAGEMENT.md` to show the `vcpkg-configuration.json`
registry approach as the primary consumer setup method, replacing the
overlay-ports-only instructions.

## Why

- The previous baseline (`c144e46f`) predated three patch removals that
  simplified portfiles; staying on it would install older, patchier ports.
- The documentation only described `--overlay-ports` for consumers; the
  remote registry option was listed as an alternative without a concrete
  `vcpkg-configuration.json` snippet.
- All eight ecosystem repositories now use the remote registry pattern
  (tracked in #531); the docs should reflect this.

Closes #531

## Where

- `vcpkg-configuration.json`
- `docs/guides/PORT_MANAGEMENT.md`

## How

### Changes
- `vcpkg-configuration.json`: bump kcenon registry baseline `c144e46f` → `77cc46d5`
- `PORT_MANAGEMENT.md`: replace overlay-only consumer setup with full
  `vcpkg-configuration.json` snippet; note all 8 repos use this pattern

### Sub-PRs (ecosystem repos)
| Repository | PR |
|-----------|-----|
| common_system | kcenon/common_system#450 |
| thread_system | kcenon/thread_system#584 |
| logger_system | kcenon/logger_system#494 |
| container_system | kcenon/container_system#421 |
| database_system | kcenon/database_system#452 |
| network_system | kcenon/network_system#840 |
| pacs_system | kcenon/pacs_system#943 |

### Test Plan
- [ ] Verify each sub-PR CI passes
- [ ] Confirm `vcpkg install kcenon-monitoring-system` resolves without `--overlay-ports`