### PR TITLE
chore(deps): standardize overlay port PACKAGE_NAME to snake_case

### DIFF
--- a/integration_tests/vcpkg_consumer/CMakeLists.txt
+++ b/integration_tests/vcpkg_consumer/CMakeLists.txt
@@ -26,24 +26,24 @@ else()
     list(APPEND MISSING_PORTS "thread_system")
 endif()
 
-find_package(ContainerSystem CONFIG)
-if(ContainerSystem_FOUND)
-    message(STATUS "Found ContainerSystem: ${ContainerSystem_DIR}")
-    list(APPEND FOUND_PORTS "ContainerSystem")
+find_package(container_system CONFIG)
+if(container_system_FOUND)
+    message(STATUS "Found container_system: ${container_system_DIR}")
+    list(APPEND FOUND_PORTS "container_system")
 else()
-    message(WARNING "ContainerSystem not found - skipping")
-    list(APPEND MISSING_PORTS "ContainerSystem")
+    message(WARNING "container_system not found - skipping")
+    list(APPEND MISSING_PORTS "container_system")
 endif()
 
 # ─── Tier 2: Logging ─────────────────────────────────────────────────────────
 
-find_package(LoggerSystem CONFIG)
-if(LoggerSystem_FOUND)
-    message(STATUS "Found LoggerSystem: ${LoggerSystem_DIR}")
-    list(APPEND FOUND_PORTS "LoggerSystem")
+find_package(logger_system CONFIG)
+if(logger_system_FOUND)
+    message(STATUS "Found logger_system: ${logger_system_DIR}")
+    list(APPEND FOUND_PORTS "logger_system")
 else()
-    message(WARNING "LoggerSystem not found - skipping")
-    list(APPEND MISSING_PORTS "LoggerSystem")
+    message(WARNING "logger_system not found - skipping")
+    list(APPEND MISSING_PORTS "logger_system")
 endif()
 
 # ─── Tier 3: Monitoring & Database ───────────────────────────────────────────
@@ -57,27 +57,27 @@ else()
     list(APPEND MISSING_PORTS "monitoring_system")
 endif()
 
-find_package(DatabaseSystem CONFIG)
-if(DatabaseSystem_FOUND)
-    message(STATUS "Found DatabaseSystem: ${DatabaseSystem_DIR}")
-    list(APPEND FOUND_PORTS "DatabaseSystem")
+find_package(database_system CONFIG)
+if(database_system_FOUND)
+    message(STATUS "Found database_system: ${database_system_DIR}")
+    list(APPEND FOUND_PORTS "database_system")
 else()
-    message(WARNING "DatabaseSystem not found - skipping")
-    list(APPEND MISSING_PORTS "DatabaseSystem")
+    message(WARNING "database_system not found - skipping")
+    list(APPEND MISSING_PORTS "database_system")
 endif()
 
 # ─── Tier 4: Networking ──────────────────────────────────────────────────────
 
-# OpenSSL is a transitive dependency of NetworkSystem
+# OpenSSL is a transitive dependency of network_system
 find_package(OpenSSL QUIET)
 
-find_package(NetworkSystem CONFIG)
-if(NetworkSystem_FOUND)
-    message(STATUS "Found NetworkSystem: ${NetworkSystem_DIR}")
-    list(APPEND FOUND_PORTS "NetworkSystem")
+find_package(network_system CONFIG)
+if(network_system_FOUND)
+    message(STATUS "Found network_system: ${network_system_DIR}")
+    list(APPEND FOUND_PORTS "network_system")
 else()
-    message(WARNING "NetworkSystem not found - skipping")
-    list(APPEND MISSING_PORTS "NetworkSystem")
+    message(WARNING "network_system not found - skipping")
+    list(APPEND MISSING_PORTS "network_system")
 endif()
 
 # ─── Tier 5: PACS ────────────────────────────────────────────────────────────

--- a/vcpkg-ports/kcenon-container-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-container-system/portfile.cmake
@@ -27,9 +27,20 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME ContainerSystem
+    PACKAGE_NAME container_system
     CONFIG_PATH lib/cmake/ContainerSystem
 )
+
+# Create snake_case config entry point for find_package(container_system)
+# Upstream installs as ContainerSystem; this wrapper standardizes the package name
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/container_system/container_system-config.cmake"
+    "include(\"\${CMAKE_CURRENT_LIST_DIR}/ContainerSystemConfig.cmake\")\n"
+)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/container_system/ContainerSystemConfigVersion.cmake")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/share/container_system/container_system-config-version.cmake"
+        "include(\"\${CMAKE_CURRENT_LIST_DIR}/ContainerSystemConfigVersion.cmake\")\n"
+    )
+endif()
 
 # Remove example/sample executables and empty bin directories
 file(REMOVE_RECURSE

--- a/vcpkg-ports/kcenon-container-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-container-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-container-system",
   "version": "0.1.0",
-  "port-version": 0,
+  "port-version": 1,
   "description": "Advanced C++20 Container System with Thread-Safe Operations and Messaging Integration",
   "homepage": "https://github.com/kcenon/container_system",
   "license": "BSD-3-Clause",

--- a/vcpkg-ports/kcenon-database-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-database-system/portfile.cmake
@@ -32,9 +32,20 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME DatabaseSystem
+    PACKAGE_NAME database_system
     CONFIG_PATH lib/cmake/DatabaseSystem
 )
+
+# Create snake_case config entry point for find_package(database_system)
+# Upstream installs as DatabaseSystem; this wrapper standardizes the package name
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/database_system/database_system-config.cmake"
+    "include(\"\${CMAKE_CURRENT_LIST_DIR}/DatabaseSystemConfig.cmake\")\n"
+)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/database_system/DatabaseSystemConfigVersion.cmake")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/share/database_system/database_system-config-version.cmake"
+        "include(\"\${CMAKE_CURRENT_LIST_DIR}/DatabaseSystemConfigVersion.cmake\")\n"
+    )
+endif()
 
 # Fix: integrated_database uses static-init registration pattern with zero source
 # files when all backends are disabled. MSVC produces no .lib for empty targets,

--- a/vcpkg-ports/kcenon-database-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-database-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-database-system",
   "version": "0.1.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Pure, lightweight C++20 Core DAL library with unified access to PostgreSQL, MySQL, SQLite, MongoDB, and Redis",
   "homepage": "https://github.com/kcenon/database_system",
   "license": "BSD-3-Clause",

--- a/vcpkg-ports/kcenon-logger-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-logger-system/portfile.cmake
@@ -33,12 +33,20 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME LoggerSystem
+    PACKAGE_NAME logger_system
     CONFIG_PATH lib/cmake/LoggerSystem
 )
 
-# v0.1.2: upstream now emits install(EXPORT LoggerSystemTargets) when
-# LOGGER_USE_THREAD_SYSTEM=OFF, so manual target generation is no longer needed.
+# Create snake_case config entry point for find_package(logger_system)
+# Upstream installs as LoggerSystem; this wrapper standardizes the package name
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/logger_system/logger_system-config.cmake"
+    "include(\"\${CMAKE_CURRENT_LIST_DIR}/LoggerSystemConfig.cmake\")\n"
+)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/logger_system/LoggerSystemConfigVersion.cmake")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/share/logger_system/logger_system-config-version.cmake"
+        "include(\"\${CMAKE_CURRENT_LIST_DIR}/LoggerSystemConfigVersion.cmake\")\n"
+    )
+endif()
 
 # Fix include paths: upstream headers use kcenon/logger/ but vcpkg installs under logger_system/
 file(GLOB_RECURSE _logger_headers "${CURRENT_PACKAGES_DIR}/include/logger_system/*.h")

--- a/vcpkg-ports/kcenon-logger-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-logger-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-logger-system",
   "version": "0.1.2",
-  "port-version": 0,
+  "port-version": 1,
   "description": "High-performance C++20 async logging framework with 4.34M msg/sec throughput, 148ns latency, and modular architecture",
   "homepage": "https://github.com/kcenon/logger_system",
   "license": "BSD-3-Clause",

--- a/vcpkg-ports/kcenon-network-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-network-system/portfile.cmake
@@ -27,17 +27,28 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME NetworkSystem
+    PACKAGE_NAME network_system
     CONFIG_PATH lib/cmake/NetworkSystem
 )
 
 # Fix upstream: NetworkSystemTargets links ZLIB::ZLIB and OpenSSL::SSL
 # but config omits find_dependency(ZLIB) and find_dependency(OpenSSL)
 vcpkg_replace_string(
-    "${CURRENT_PACKAGES_DIR}/share/NetworkSystem/NetworkSystemConfig.cmake"
+    "${CURRENT_PACKAGES_DIR}/share/network_system/NetworkSystemConfig.cmake"
     "find_dependency(asio CONFIG REQUIRED)"
     "find_dependency(OpenSSL REQUIRED)\nfind_dependency(ZLIB REQUIRED)\nfind_dependency(asio CONFIG REQUIRED)"
 )
+
+# Create snake_case config entry point for find_package(network_system)
+# Upstream installs as NetworkSystem; this wrapper standardizes the package name
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/network_system/network_system-config.cmake"
+    "include(\"\${CMAKE_CURRENT_LIST_DIR}/NetworkSystemConfig.cmake\")\n"
+)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/network_system/NetworkSystemConfigVersion.cmake")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/share/network_system/network_system-config-version.cmake"
+        "include(\"\${CMAKE_CURRENT_LIST_DIR}/NetworkSystemConfigVersion.cmake\")\n"
+    )
+endif()
 
 # Remove empty directories that cause vcpkg post-build validation warnings
 file(REMOVE_RECURSE

--- a/vcpkg-ports/kcenon-network-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-network-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-network-system",
   "version": "0.1.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Modern C++20 async network library with TCP/UDP, HTTP/1.1, WebSocket, and TLS 1.3 support",
   "homepage": "https://github.com/kcenon/network_system",
   "license": "BSD-3-Clause",

--- a/vcpkg-ports/kcenon-pacs-system/fix-vcpkg-dependency-discovery.patch
+++ b/vcpkg-ports/kcenon-pacs-system/fix-vcpkg-dependency-discovery.patch
@@ -28,7 +28,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 +
 +    # vcpkg: fallback to find_package
 +    if(NOT CONTAINER_SYSTEM_FOUND)
-+        find_package(ContainerSystem CONFIG QUIET)
++        find_package(container_system CONFIG QUIET)
 +        if(TARGET ContainerSystem::container)
 +            if(NOT TARGET container_system)
 +                add_library(container_system ALIAS ContainerSystem::container)
@@ -70,7 +70,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 +
 +# vcpkg: fallback to find_package
 +if(NOT LOGGER_SYSTEM_FOUND)
-+    find_package(LoggerSystem CONFIG QUIET)
++    find_package(logger_system CONFIG QUIET)
 +    if(TARGET LoggerSystem::LoggerSystem)
 +        if(NOT TARGET LoggerSystem)
 +            add_library(LoggerSystem ALIAS LoggerSystem::LoggerSystem)
@@ -90,7 +90,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 +
 +    # vcpkg: fallback to find_package
 +    if(NOT NETWORK_SYSTEM_FOUND)
-+        find_package(NetworkSystem CONFIG QUIET)
++        find_package(network_system CONFIG QUIET)
 +        if(TARGET NetworkSystem::NetworkSystem)
 +            if(NOT TARGET NetworkSystem)
 +                add_library(NetworkSystem ALIAS NetworkSystem::NetworkSystem)

--- a/vcpkg-ports/kcenon-pacs-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-pacs-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-pacs-system",
   "version": "0.1.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Modern C++20 PACS (Picture Archiving and Communication System) built on the kcenon ecosystem",
   "homepage": "https://github.com/kcenon/pacs_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Closes #542
Part of #532

## Summary

- Standardize all 8 ecosystem vcpkg overlay ports to use `snake_case` PACKAGE_NAME convention for `find_package()` calls
- Add thin config wrappers for the 4 PascalCase ports (logger, container, database, network) that delegate to upstream config files
- Update vcpkg consumer integration test and pacs dependency discovery patch

### PACKAGE_NAME Changes

| Port | Before | After |
|------|--------|-------|
| kcenon-logger-system | `LoggerSystem` | `logger_system` |
| kcenon-container-system | `ContainerSystem` | `container_system` |
| kcenon-database-system | `DatabaseSystem` | `database_system` |
| kcenon-network-system | `NetworkSystem` | `network_system` |
| kcenon-common-system | `common_system` | (unchanged) |
| kcenon-thread-system | `thread_system` | (unchanged) |
| kcenon-monitoring-system | `monitoring_system` | (unchanged) |
| kcenon-pacs-system | `pacs_system` | (unchanged) |

### Approach

Each changed portfile uses `vcpkg_cmake_config_fixup(PACKAGE_NAME snake_case CONFIG_PATH lib/cmake/PascalCase)` to move files under the snake_case share directory, then creates a `snake_case-config.cmake` wrapper that includes the original `PascalCaseConfig.cmake`. This avoids patching upstream CMake install/export rules while providing a consistent `find_package()` API.

### Files Changed

- 4 portfiles: PACKAGE_NAME + config wrappers
- 5 vcpkg.json: port-version bumps
- 1 patch: pacs dependency discovery updated for snake_case
- 1 integration test: vcpkg_consumer migrated to snake_case

## Test Plan

- [ ] CI vcpkg integration test (`vcpkg_chain_consumer`) passes with snake_case `find_package()` names
- [ ] All platform builds (Ubuntu, macOS, Windows) pass
- [ ] No regression in main monitoring_system build