### PR TITLE
chore(deps): bump port-versions and fix README after PR #547 portfile changes

### DIFF
--- a/vcpkg-ports/README.md
+++ b/vcpkg-ports/README.md
@@ -10,12 +10,12 @@ real SHA512 hashes, upstream patches, and CI validation.
 |---------|---------|-------------|---------|--------------|
 | kcenon-common-system | 0.2.0 | 0 | — | None |
 | kcenon-thread-system | 0.3.0 | 0 | — | common-system, simdutf |
-| kcenon-logger-system | 0.1.2 | 1 | fix-unified-deps-target-names | common-system, thread-system, fmt, libiconv |
+| kcenon-logger-system | 0.1.2 | 2 | — | common-system, thread-system, fmt, libiconv |
 | kcenon-container-system | 0.1.0 | 1 | — | common-system |
 | kcenon-monitoring-system | 0.1.0 | 0 | — | common-system, thread-system |
 | kcenon-database-system | 0.1.0 | 3 | fix-common-system-target | common-system |
-| kcenon-network-system | 0.1.0 | 4 | fix-common-system-target | common-system, thread-system, logger-system, asio, openssl |
-| kcenon-pacs-system | 0.1.0 | 3 | fix-vcpkg-dependency-discovery | common-system, container-system, network-system |
+| kcenon-network-system | 0.1.0 | 5 | fix-common-system-target | common-system, thread-system, logger-system, asio, openssl |
+| kcenon-pacs-system | 0.1.0 | 5 | fix-vcpkg-dependency-discovery | common-system, container-system, network-system |
 
 ## PACKAGE_NAME Convention
 
@@ -75,19 +75,18 @@ When adding a new ecosystem port, follow these rules:
 
 ### Upstream Adoption Status
 
-Four upstream repositories still install CMake config files under a PascalCase path.
+Three upstream repositories still install CMake config files under a PascalCase path.
 Upstream issues have been filed requesting native snake_case support. Once each upstream
 merges the change, the corresponding portfile can drop its `CONFIG_PATH` override and
 wrapper config file.
 
 | Repository | Current Config Path | Target Config Path | Upstream Issue | Portfile Cleanup |
 |------------|--------------------|--------------------|----------------|------------------|
-| kcenon/logger_system | `lib/cmake/LoggerSystem` | `lib/cmake/logger_system` | [#502](https://github.com/kcenon/logger_system/issues/502) | Remove wrapper + `CONFIG_PATH` |
 | kcenon/container_system | `lib/cmake/ContainerSystem` | `lib/cmake/container_system` | [#424](https://github.com/kcenon/container_system/issues/424) | Remove wrapper + `CONFIG_PATH` |
 | kcenon/database_system | `lib/cmake/DatabaseSystem` | `lib/cmake/database_system` | [#455](https://github.com/kcenon/database_system/issues/455) | Remove wrapper + `CONFIG_PATH` |
 | kcenon/network_system | `lib/cmake/NetworkSystem` | `lib/cmake/network_system` | [#843](https://github.com/kcenon/network_system/issues/843) | Remove wrapper + `CONFIG_PATH` |
 
-The remaining four ports (common_system, thread_system, monitoring_system, pacs_system)
+The remaining five ports (common_system, logger_system, thread_system, monitoring_system, pacs_system)
 already install under snake_case paths and need no wrapper.
 
 ## Quick Start

--- a/vcpkg-ports/kcenon-logger-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-logger-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-logger-system",
   "version": "0.1.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "High-performance C++20 async logging framework with 4.34M msg/sec throughput, 148ns latency, and modular architecture",
   "homepage": "https://github.com/kcenon/logger_system",
   "license": "BSD-3-Clause",

--- a/vcpkg-ports/kcenon-network-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-network-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-network-system",
   "version": "0.1.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Modern C++20 async network library with TCP/UDP, HTTP/1.1, WebSocket, and TLS 1.3 support",
   "homepage": "https://github.com/kcenon/network_system",
   "license": "BSD-3-Clause",

--- a/vcpkg-ports/kcenon-pacs-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-pacs-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-pacs-system",
   "version": "0.1.0",
-  "port-version": 3,
+  "port-version": 5,
   "description": "Modern C++20 PACS (Picture Archiving and Communication System) built on the kcenon ecosystem",
   "homepage": "https://github.com/kcenon/pacs_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## What

### Summary
Corrects missed port-version increments from PR #547 and fixes outdated documentation in `vcpkg-ports/README.md`.

### Change Type
- [x] Chore

### Affected Components
- `vcpkg-ports/kcenon-logger-system/vcpkg.json`
- `vcpkg-ports/kcenon-network-system/vcpkg.json`
- `vcpkg-ports/kcenon-pacs-system/vcpkg.json`
- `vcpkg-ports/README.md`

## Why

### Problem Solved
PR #547 changed portfiles for logger, pacs, and network but did not bump their
`port-version` fields. vcpkg uses `port-version` to detect portfile changes in
overlay ports; stale versions prevent consumers from picking up fixes.

Additionally, the README "Upstream Adoption Status" table still listed
`kcenon/logger_system` as pending, even though upstream merged snake_case support
in PR #501 and our portfile was already updated in PR #547.

### Related Issues
- Part of #532 (Standardize CMake PACKAGE_NAME convention across ecosystem ports)
- Follows up on #547 (logger-system native snake_case update)

## Where

### Port-Version Bumps

| Port | Old | New | Reason |
|------|-----|-----|--------|
| kcenon-logger-system | 1 | 2 | New REF, removed patch, snake_case CONFIG_PATH (PR #547) |
| kcenon-pacs-system | 3 | 5 | Two portfile changes in PR #547 (config fixup + regex replace) |
| kcenon-network-system | 4 | 5 | Config fixup for ContainerSystem → container_system (PR #547) |

### README Fixes

- Canonical Status: logger row now shows `port-version: 2` and `—` (no patch)
- Upstream Adoption Status: logger_system row removed (upstream already resolved)
- "Remaining ports" count updated from 4 → 5 (now includes logger_system)

## How

### Testing Done
- [x] Verified port-version values match actual portfile change counts since last increment
- [x] Verified README Upstream Adoption Status accurately reflects current upstream state

### Test Plan
1. Check `vcpkg-ports/kcenon-logger-system/vcpkg.json` → `"port-version": 2`
2. Check `vcpkg-ports/kcenon-pacs-system/vcpkg.json` → `"port-version": 5`
3. Check `vcpkg-ports/kcenon-network-system/vcpkg.json` → `"port-version": 5`
4. Check README table: logger row shows `2 | —`
5. Check README: Upstream Adoption Status has 3 rows (no logger)

### Breaking Changes
None — port-version bumps are forward-only and do not break existing builds.