### PR TITLE
fix(deps): Add benchmark 1.8.3 override to vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,7 +14,8 @@
   "overrides": [
     { "name": "grpc", "version": "1.51.1" },
     { "name": "protobuf", "version": "3.21.12" },
-    { "name": "gtest", "version": "1.14.0" }
+    { "name": "gtest", "version": "1.14.0" },
+    { "name": "benchmark", "version": "1.8.3" }
   ],
   "features": {
     "grpc": {


### PR DESCRIPTION
## Summary
- Add benchmark 1.8.3 version override to vcpkg.json overrides array
- Aligns monitoring_system with all 7 peer ecosystem systems that already pin this version

## Related Issues
- Closes #564
- Part of kcenon/common_system#454

## Test plan
- [ ] Verify vcpkg.json is valid JSON
- [ ] Verify benchmark override version matches ecosystem standard (1.8.3)