### PR TITLE
chore(deps): Remove fmt from logger-system overlay port

### DIFF
--- a/vcpkg-ports/README.md
+++ b/vcpkg-ports/README.md
@@ -10,7 +10,7 @@ the canonical [vcpkg-registry](https://github.com/kcenon/vcpkg-registry) with CI
 |---------|---------|-------------|---------|--------------|
 | kcenon-common-system | 0.2.0 | 0 | — | None |
 | kcenon-thread-system | 0.3.1 | — | — | common-system, simdutf |
-| kcenon-logger-system | 0.1.3 | — | — | common-system, thread-system, fmt, libiconv |
+| kcenon-logger-system | 0.1.3 | — | — | common-system, libiconv |
 | kcenon-container-system | 0.1.0 | 2 | — | common-system |
 | kcenon-monitoring-system | 0.1.0 | 1 | — | common-system, thread-system |
 | kcenon-database-system | 0.1.0 | 3 | — | common-system, asio |

--- a/vcpkg-ports/kcenon-logger-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-logger-system/vcpkg.json
@@ -8,10 +8,6 @@
   "dependencies": [
     "kcenon-common-system",
     {
-      "name": "fmt",
-      "version>=": "10.0.0"
-    },
-    {
       "name": "libiconv",
       "platform": "!windows"
     },


### PR DESCRIPTION
## Summary
- Remove `fmt >= 10.0.0` from `vcpkg-ports/kcenon-logger-system/vcpkg.json` dependencies
- Update `vcpkg-ports/README.md` dependency table

## Why
Syncs overlay port with the canonical vcpkg-registry change. logger_system uses C++20 `std::format` exclusively — the `fmt` dependency was a leftover.

Closes #568

## Test plan
- [ ] Overlay port JSON is valid
- [ ] README dependency table is accurate