### PR TITLE
fix(vcpkg-ports): enable thread_system integration in logger_system port

### DIFF
--- a/vcpkg-ports/kcenon-logger-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-logger-system/portfile.cmake
@@ -9,9 +9,9 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-# Disable thread_system integration: upstream CMake does not link thread_system
-# library properly in vcpkg mode (unresolved externals for thread_pool symbols).
-# The logger falls back to its standalone executor which works correctly.
+# Enable thread_system integration: logger_system uses thread_system's optimized
+# thread pool (work stealing, lock-free queues) for async log dispatch.
+# Requires kcenon-thread-system to be installed (declared in vcpkg.json deps).
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -20,7 +20,7 @@ vcpkg_cmake_configure(
         -DBUILD_SAMPLES=OFF
         -DLOGGER_BUILD_INTEGRATION_TESTS=OFF
         -DLOGGER_ENABLE_COVERAGE=OFF
-        -DLOGGER_USE_THREAD_SYSTEM=OFF
+        -DLOGGER_USE_THREAD_SYSTEM=ON
 )
 
 vcpkg_cmake_install()

--- a/vcpkg-ports/kcenon-logger-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-logger-system/vcpkg.json
@@ -7,6 +7,7 @@
   "supports": "!(uwp | xbox)",
   "dependencies": [
     "kcenon-common-system",
+    "kcenon-thread-system",
     {
       "name": "libiconv",
       "platform": "!windows"


### PR DESCRIPTION
## What

### Summary
Enable `LOGGER_USE_THREAD_SYSTEM=ON` in the `kcenon-logger-system` overlay port and add `kcenon-thread-system` as a runtime dependency. Removes the `-DLOGGER_USE_THREAD_SYSTEM=OFF` workaround that was disabling thread_system integration.

### Change Type
- [x] Bugfix

## Why

### Related Issues
- Closes kcenon/logger_system#507

### Motivation
The portfile previously forced `LOGGER_USE_THREAD_SYSTEM=OFF` as a workaround for unresolved externals when linking thread_pool symbols. Since then, both logger_system and thread_system have undergone CMake improvements:

- logger_system correctly detects IMPORTED targets and links them PUBLIC
- thread_system completed the snake_case export migration with proper unified build
- The config template correctly calls `find_dependency(thread_system CONFIG REQUIRED)`

With thread_system disabled, vcpkg consumers miss the optimized thread pool (work stealing, lock-free queues) for async log dispatch, falling back to a standalone `std::jthread`-based executor.

## Where

### Files Changed
| File | Change |
|------|--------|
| `vcpkg-ports/kcenon-logger-system/vcpkg.json` | Add `kcenon-thread-system` to dependencies |
| `vcpkg-ports/kcenon-logger-system/portfile.cmake` | Change `LOGGER_USE_THREAD_SYSTEM` from OFF to ON |

## How

### Implementation
1. Added `"kcenon-thread-system"` to the port's `dependencies` array
2. Changed `-DLOGGER_USE_THREAD_SYSTEM=OFF` to `-DLOGGER_USE_THREAD_SYSTEM=ON`
3. Updated comments to reflect the enabled state

### Test Plan
- `vcpkg install kcenon-logger-system` with overlay ports should build successfully with thread_system linked
- Consumer `find_package(logger_system CONFIG)` should resolve `thread_system` as a transitive dependency
- `LoggerSystem_USE_THREAD_SYSTEM` should be `ON` in the installed config
- Logger async operations should use thread_system's thread pool