### PR TITLE
docs(doxygen): migrate to shared workflow and standardize Doxyfile

### DIFF
--- a/.github/workflows/build-Doxygen.yaml
+++ b/.github/workflows/build-Doxygen.yaml
@@ -7,43 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
-  generate-and-deploy:
-    if: github.ref != 'refs/heads/gh-pages'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: true
-          fetch-depth: 1
-
-      - name: Checkout common_system dependency
-        uses: actions/checkout@v6
-        with:
-          repository: kcenon/common_system
-          path: common_system
-
-      - name: Install Doxygen and Graphviz
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y doxygen graphviz
-
-      - name: Generate documentation
-        run: doxygen Doxyfile
-
-      - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./documents/html
-          force_orphan: true
-          enable_jekyll: false
-          commit_message: 'docs(gh-pages): update API documentation [skip ci]'
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
+  docs:
+    uses: kcenon/common_system/.github/workflows/doxygen.yml@main
+    with:
+      checkout-submodules: 'true'
+      checkout-common-system: true
+    secrets: inherit

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,4 +1,5 @@
 PROJECT_NAME           = "Monitoring System"
+PROJECT_NUMBER         = "0.1.0"
 PROJECT_BRIEF          = "System resource monitoring with pluggable collectors and alerting"
 OUTPUT_DIRECTORY       = documents
 CREATE_SUBDIRS         = YES


### PR DESCRIPTION
## What

### Summary
Replace inline Doxygen workflow (50 lines) with the shared reusable workflow from common_system (15 lines). Add PROJECT_NUMBER to Doxyfile.

### Change Type
- [x] Documentation
- [x] Chore

## Why

### Related Issues
- Closes #578 (Migrate to shared Doxygen workflow)
- Part of kcenon/common_system#461 (Ecosystem Doxygen standardization epic)

### Motivation
The inline workflow duplicates logic already centralized in common_system's shared workflow. This divergence causes version drift (e.g., `actions/checkout@v6` vs `@v5` in the shared workflow) and increases maintenance burden.

## Where

### Files Changed
| File | Change |
|------|--------|
| `.github/workflows/build-Doxygen.yaml` | 50 lines → 15 lines (shared workflow) |
| `Doxyfile` | Add PROJECT_NUMBER = 0.1.0 |

## How

### Implementation Details
1. **Workflow migration**: Replaced inline steps with `uses: kcenon/common_system/.github/workflows/doxygen.yml@main`
2. **Common system checkout**: `checkout-common-system: true` preserves the existing dependency checkout
3. **Submodules**: `checkout-submodules: 'true'` preserves the existing submodule checkout
4. **PROJECT_NUMBER**: Added `0.1.0` to match `vcpkg.json` version

### Testing Done
- [x] Workflow YAML syntax validated
- [x] Shared workflow input parameters verified against common_system definition
- [x] Doxyfile settings verified

### Test Plan
1. PR triggers Doxygen build (no deploy) — verify build succeeds
2. After merge, push to main triggers build + deploy
3. Verify GitHub Pages still accessible