### PR TITLE
docs(readme): add License badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Code Coverage](https://github.com/kcenon/monitoring_system/actions/workflows/coverage.yml/badge.svg)](https://github.com/kcenon/monitoring_system/actions/workflows/coverage.yml)
 [![Static Analysis](https://github.com/kcenon/monitoring_system/actions/workflows/static-analysis.yml/badge.svg)](https://github.com/kcenon/monitoring_system/actions/workflows/static-analysis.yml)
 [![Documentation](https://github.com/kcenon/monitoring_system/actions/workflows/build-Doxygen.yaml/badge.svg)](https://github.com/kcenon/monitoring_system/actions/workflows/build-Doxygen.yaml)
+[![License](https://img.shields.io/github/license/kcenon/monitoring_system)](https://github.com/kcenon/monitoring_system/blob/main/LICENSE)
 
 # Monitoring System
 


### PR DESCRIPTION
Part of kcenon/common_system#467

## Summary
- Add License badge for BSD-3-Clause to match ecosystem standard

## Test plan
- [ ] Badge renders correctly on GitHub