### PR TITLE
docs(readme): Add codecov badge

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -1,6 +1,7 @@
 [![CI](https://github.com/kcenon/monitoring_system/actions/workflows/ci.yml/badge.svg)](https://github.com/kcenon/monitoring_system/actions/workflows/ci.yml)
 [![Code Coverage](https://github.com/kcenon/monitoring_system/actions/workflows/coverage.yml/badge.svg)](https://github.com/kcenon/monitoring_system/actions/workflows/coverage.yml)
 [![Static Analysis](https://github.com/kcenon/monitoring_system/actions/workflows/static-analysis.yml/badge.svg)](https://github.com/kcenon/monitoring_system/actions/workflows/static-analysis.yml)
+[![codecov](https://codecov.io/gh/kcenon/monitoring_system/branch/main/graph/badge.svg)](https://codecov.io/gh/kcenon/monitoring_system)
 [![Documentation](https://github.com/kcenon/monitoring_system/actions/workflows/build-Doxygen.yaml/badge.svg)](https://github.com/kcenon/monitoring_system/actions/workflows/build-Doxygen.yaml)
 
 # Monitoring System Project

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![CI](https://github.com/kcenon/monitoring_system/actions/workflows/ci.yml/badge.svg)](https://github.com/kcenon/monitoring_system/actions/workflows/ci.yml)
 [![Code Coverage](https://github.com/kcenon/monitoring_system/actions/workflows/coverage.yml/badge.svg)](https://github.com/kcenon/monitoring_system/actions/workflows/coverage.yml)
 [![Static Analysis](https://github.com/kcenon/monitoring_system/actions/workflows/static-analysis.yml/badge.svg)](https://github.com/kcenon/monitoring_system/actions/workflows/static-analysis.yml)
+[![codecov](https://codecov.io/gh/kcenon/monitoring_system/branch/main/graph/badge.svg)](https://codecov.io/gh/kcenon/monitoring_system)
 [![Documentation](https://github.com/kcenon/monitoring_system/actions/workflows/build-Doxygen.yaml/badge.svg)](https://github.com/kcenon/monitoring_system/actions/workflows/build-Doxygen.yaml)
 [![License](https://img.shields.io/github/license/kcenon/monitoring_system)](https://github.com/kcenon/monitoring_system/blob/main/LICENSE)
 


### PR DESCRIPTION
## What

### Summary
Add codecov.io badge to README.md and README.kr.md, placed after Static Analysis badge.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Closes kcenon/common_system#473

### Motivation
Standardize badge set across ecosystem — codecov badge was present in 4/8 repos (thread, container, database, network) but missing from this repo.

## How

### Test Plan
- [ ] Badge renders correctly on GitHub
- [ ] Badge links to correct codecov.io project page