### PR TITLE
docs: Add CHANGELOG.md and CONTRIBUTING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-03-11
+
+### Added
+- Pluggable metric collector architecture with factory pattern
+- System resource collectors (CPU, memory, disk, network)
+- Distributed tracing with OpenTelemetry-compatible context propagation
+- Alert system with configurable thresholds and circuit breakers
+- Custom Doxygen ALIASES (@thread_safety, @performance)
+- Ecosystem integration adapters (thread_system, logger_system, container_system)
+- C++20 concepts for collector validation
+- gRPC transport for OTLP trace export
+- Plugin system (built-in and dynamic shared library plugins)
+- Dependabot and OSV-Scanner vulnerability monitoring (#501)
+- SBOM generation and CVE scanning workflows (#500)
+- IEC 62304 SOUP compliance documentation (#492)
+- vcpkg overlay ports for ecosystem dependencies
+
+### Infrastructure
+- GitHub Actions CI/CD with sanitizer testing
+- Doxygen documentation workflow
+- vcpkg manifest with optional features (grpc, logging)
+- Cross-platform support (Linux, macOS, Windows)


### PR DESCRIPTION
## What

### Summary
Add CHANGELOG.md (Keep a Changelog format) and CONTRIBUTING.md (standardized contributor guide) to the repository.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Part of kcenon/common_system#475

### Motivation
- **CHANGELOG.md**: vcpkg users need to track breaking changes between versions. Previously only network_system had one (1/8 repos).
- **CONTRIBUTING.md**: GitHub displays a link to this file on issue/PR creation pages, improving contributor onboarding. Previously only monitoring_system had one (1/8 repos).

## How

### Implementation Details
- CHANGELOG.md generated from git tags with key commit summaries
- CONTRIBUTING.md follows ecosystem-standard template with build instructions, code standards, and PR guidelines

### Test Plan
- [ ] CHANGELOG.md version dates match git tags
- [ ] CONTRIBUTING.md build instructions are accurate