### PR TITLE
fix(vcpkg): Add network feature definition to source manifest

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -37,6 +37,12 @@
         "kcenon-logger-system"
       ]
     },
+    "network": {
+      "description": "Enable network_system integration for HTTP metrics export (OTLP, Prometheus)",
+      "dependencies": [
+        "kcenon-network-system"
+      ]
+    },
     "testing": {
       "description": "Build unit tests",
       "dependencies": [


### PR DESCRIPTION
## Summary
- Add `network` feature to `vcpkg.json` with `kcenon-network-system` dependency
- Aligns source manifest with registry port definition

## Why

The registry port (`vcpkg-registry/ports/kcenon-monitoring-system/vcpkg.json`) defines a `network` feature for HTTP metrics export integration, but the source manifest did not include it. This inconsistency prevents local developers from using `vcpkg install kcenon-monitoring-system[network]` against the source manifest.

Closes #589

## Where

| File | Change |
|------|--------|
| `vcpkg.json` | Added `network` feature with `kcenon-network-system` dependency |

## Test plan
- [ ] `vcpkg install kcenon-monitoring-system[network]` resolves correctly using source manifest
- [ ] Existing features (`grpc`, `logging`, `testing`) unaffected