### PR TITLE
chore(build): add CMakePresets.json for vcpkg build integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ docs/latex/
 # Benchmark results
 benchmark_results/
 *.json
+!CMakePresets.json
+!CMakeUserPresets.json
+!vcpkg.json
+!vcpkg-configuration.json
 
 # Coverage
 *.gcda

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,153 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 20,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "default",
+            "displayName": "Default Config",
+            "description": "Default build using system-installed external packages",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "MONITORING_BUILD_TESTS": "OFF",
+                "MONITORING_BUILD_INTEGRATION_TESTS": "OFF",
+                "MONITORING_BUILD_EXAMPLES": "OFF",
+                "MONITORING_BUILD_BENCHMARKS": "OFF"
+            }
+        },
+        {
+            "name": "debug",
+            "displayName": "Debug",
+            "description": "Debug build with tests enabled",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "MONITORING_BUILD_TESTS": "ON",
+                "MONITORING_BUILD_INTEGRATION_TESTS": "ON",
+                "MONITORING_BUILD_EXAMPLES": "ON",
+                "MONITORING_ENABLE_COVERAGE": "ON"
+            }
+        },
+        {
+            "name": "release",
+            "displayName": "Release",
+            "description": "Optimized release build",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "full",
+            "displayName": "Full Integration",
+            "description": "Debug build with all optional integrations enabled",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-full",
+            "cacheVariables": {
+                "MONITORING_WITH_LOGGER_SYSTEM": "ON",
+                "MONITORING_WITH_NETWORK_SYSTEM": "ON",
+                "MONITORING_WITH_GRPC": "ON"
+            }
+        },
+        {
+            "name": "asan",
+            "displayName": "AddressSanitizer",
+            "description": "Build with AddressSanitizer",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-asan",
+            "cacheVariables": {
+                "MONITORING_ENABLE_ASAN": "ON"
+            }
+        },
+        {
+            "name": "tsan",
+            "displayName": "ThreadSanitizer",
+            "description": "Build with ThreadSanitizer",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-tsan",
+            "cacheVariables": {
+                "MONITORING_ENABLE_TSAN": "ON"
+            }
+        },
+        {
+            "name": "ubsan",
+            "displayName": "UndefinedBehaviorSanitizer",
+            "description": "Build with UndefinedBehaviorSanitizer",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-ubsan",
+            "cacheVariables": {
+                "MONITORING_ENABLE_UBSAN": "ON"
+            }
+        },
+        {
+            "name": "ci",
+            "displayName": "CI Build",
+            "description": "Configuration for continuous integration",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-ci",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "MONITORING_BUILD_TESTS": "ON",
+                "MONITORING_BUILD_INTEGRATION_TESTS": "ON",
+                "MONITORING_BUILD_BENCHMARKS": "ON"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default"
+        },
+        {
+            "name": "debug",
+            "configurePreset": "debug"
+        },
+        {
+            "name": "release",
+            "configurePreset": "release"
+        },
+        {
+            "name": "full",
+            "configurePreset": "full"
+        },
+        {
+            "name": "asan",
+            "configurePreset": "asan"
+        },
+        {
+            "name": "tsan",
+            "configurePreset": "tsan"
+        },
+        {
+            "name": "ubsan",
+            "configurePreset": "ubsan"
+        },
+        {
+            "name": "ci",
+            "configurePreset": "ci"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "ci",
+            "configurePreset": "ci",
+            "output": {
+                "outputOnFailure": true,
+                "verbosity": "verbose"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## What

### Summary
Add standardized `CMakePresets.json` to monitoring_system, aligning with the ecosystem pattern. Also fix `.gitignore` to allow project JSON files blocked by the `*.json` rule.

### Change Type
- [x] Chore (build configuration)

## Why

### Related Issues
- Closes #591

### Motivation
monitoring_system is one of 4 ecosystem repos missing CMakePresets.json. With 15+ CMake options, presets are especially valuable for this project. Additionally, the `.gitignore` `*.json` rule (intended for benchmark results) was blocking new JSON files.

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `CMakePresets.json` | New file |
| `.gitignore` | Add negation patterns for project JSON files |

## How

### Presets Included

| Preset | Build Type | Tests | Notes |
|--------|-----------|-------|-------|
| `default` | Release | OFF | Minimal build |
| `debug` | Debug | ON | Development build with coverage |
| `release` | Release | OFF | Optimized build |
| `full` | Debug | ON | All integrations (logger, network, grpc) |
| `asan` | Debug | ON | Uses `MONITORING_ENABLE_ASAN` |
| `tsan` | Debug | ON | Uses `MONITORING_ENABLE_TSAN` |
| `ubsan` | Debug | ON | Uses `MONITORING_ENABLE_UBSAN` |
| `ci` | RelWithDebInfo | ON | CI pipeline build |

Sanitizer presets use native `MONITORING_ENABLE_*` flags rather than raw `CMAKE_CXX_FLAGS` to leverage the project's internal compiler detection logic.

### .gitignore Fix

Added negation patterns so project JSON files are not ignored:
```
!CMakePresets.json
!CMakeUserPresets.json
!vcpkg.json
!vcpkg-configuration.json
```

### Testing Done
- [x] Preset structure follows ecosystem pattern (version 3, CMake 3.20+)
- [x] Sanitizer presets use native MONITORING_ENABLE_* options
- [x] .gitignore correctly excludes benchmark JSON but allows project JSON