### PR TITLE
perf(core): lazy-initialize thread_local_buffer to reduce memory waste

### DIFF
--- a/include/kcenon/monitoring/core/thread_local_buffer.h
+++ b/include/kcenon/monitoring/core/thread_local_buffer.h
@@ -81,7 +81,9 @@ struct metric_sample {
  * Each thread maintains its own buffer for recording metrics without locks.
  * When the buffer fills up, it flushes to a central collector.
  *
- * Optimized with pre-allocated ring buffer to eliminate runtime allocations.
+ * Uses lazy initialization: capacity is reserved at construction but
+ * elements are constructed on first use. This avoids wasting memory
+ * for short-lived threads that never record any metrics.
  *
  * @thread_safety NOT thread-safe across threads (thread-local use only).
  *                Thread-safe within a single thread (no concurrent access).
@@ -116,7 +118,7 @@ public:
      * @return true if recorded, false if buffer is full (caller should flush)
      *
      * @thread_safety Thread-safe (single-threaded access guaranteed by TLS)
-     * @performance O(1) - direct array write, ~5-10 ns (no allocation)
+     * @performance O(1) amortized - direct array write after initial growth
      */
     bool record(const metric_sample& sample);
 

--- a/src/core/thread_local_buffer.cpp
+++ b/src/core/thread_local_buffer.cpp
@@ -42,8 +42,10 @@ thread_local_buffer::thread_local_buffer(size_t capacity,
     : capacity_(capacity)
     , collector_(collector)
     , stats_() {
-    // Pre-allocate buffer to avoid runtime allocations
-    buffer_.resize(capacity);
+    // Reserve capacity but defer allocation until first use.
+    // Short-lived threads that never record metrics avoid the cost
+    // of constructing `capacity` metric_sample objects up front.
+    buffer_.reserve(capacity);
 }
 
 thread_local_buffer::~thread_local_buffer() {
@@ -58,8 +60,12 @@ bool thread_local_buffer::record(const metric_sample& sample) {
         return false;  // Buffer full, caller should flush
     }
 
-    // Direct write to pre-allocated slot (no allocation)
-    buffer_[write_index_] = sample;
+    // Grow the vector lazily on first use (capacity is already reserved)
+    if (write_index_ < buffer_.size()) {
+        buffer_[write_index_] = sample;
+    } else {
+        buffer_.push_back(sample);
+    }
     ++write_index_;
     ++stats_.total_records;
     return true;


### PR DESCRIPTION
## Summary
- Change `thread_local_buffer` constructor from eager `resize(capacity)` to lazy `reserve(capacity)`
- Elements are now constructed on first `record()` call instead of at buffer creation time
- Short-lived threads that never record metrics no longer allocate unused `metric_sample` objects

## Test plan
- [x] Local build passes (`cmake --preset default && cmake --build build`)
- [ ] CI validates on all platforms
- [ ] Existing monitoring tests pass without modification