### PR TITLE
Add missing find_dependency calls for optional features in config template

### DIFF
--- a/cmake/monitoring_system-config.cmake.in
+++ b/cmake/monitoring_system-config.cmake.in
@@ -6,16 +6,27 @@ include(CMakeFindDependencyMacro)
 find_dependency(Threads REQUIRED)
 find_dependency(common_system CONFIG REQUIRED)
 
-# Optional dependencies
+# Conditional dependencies based on build configuration
 set(MONITORING_USE_THREAD_SYSTEM @MONITORING_WITH_THREAD_SYSTEM@)
 set(MONITORING_USE_LOGGER_SYSTEM @MONITORING_WITH_LOGGER_SYSTEM@)
+set(MONITORING_USE_NETWORK_SYSTEM @MONITORING_WITH_NETWORK_SYSTEM@)
+set(MONITORING_USE_GRPC @MONITORING_WITH_GRPC@)
 
 if(MONITORING_USE_THREAD_SYSTEM)
-    find_dependency(thread_system CONFIG)
+    find_dependency(thread_system CONFIG REQUIRED)
 endif()
 
 if(MONITORING_USE_LOGGER_SYSTEM)
     find_dependency(logger_system CONFIG)
+endif()
+
+if(MONITORING_USE_NETWORK_SYSTEM)
+    find_dependency(network_system CONFIG REQUIRED)
+endif()
+
+if(MONITORING_USE_GRPC)
+    find_dependency(gRPC CONFIG REQUIRED)
+    find_dependency(Protobuf CONFIG REQUIRED)
 endif()
 
 # Include targets


### PR DESCRIPTION
## Summary
- Add `find_dependency(network_system CONFIG REQUIRED)` for `network` feature
- Add `find_dependency(gRPC CONFIG REQUIRED)` and `find_dependency(Protobuf CONFIG REQUIRED)` for `grpc` feature
- Make `find_dependency(thread_system CONFIG REQUIRED)` (was missing REQUIRED)

Without these, consumers linking against monitoring_system built with `network` or `grpc` features enabled would fail at link time because the required imported targets were not resolved.

## Test plan
- [ ] CI builds pass with default features
- [ ] vcpkg consumer test with `monitoring-system[network]` finds network_system
- [ ] vcpkg consumer test with `monitoring-system[grpc]` finds gRPC and Protobuf

Closes #603