### PR TITLE
fix(tests): resolve Windows platform test failures in network and interrupt collectors

### DIFF
--- a/tests/test_interrupt_collector.cpp
+++ b/tests/test_interrupt_collector.cpp
@@ -107,8 +107,14 @@ TEST_F(InterruptCollectorTest, TracksStatistics) {
     collector_->collect();
 
     auto stats = collector_->get_statistics();
-    EXPECT_GE(stats["collection_count"], 2.0);
-    EXPECT_GE(stats["collection_errors"], 0.0);
+    if (collector_->is_interrupt_monitoring_available()) {
+        // On platforms with interrupt monitoring, collections should succeed
+        EXPECT_GE(stats["collection_count"], 2.0);
+    } else {
+        // On platforms without interrupt monitoring (e.g. Windows),
+        // collections fail gracefully and increment error count instead
+        EXPECT_GE(stats["collection_errors"], 2.0);
+    }
 }
 
 // Test collect returns metrics (graceful degradation when unavailable)
@@ -122,10 +128,16 @@ TEST_F(InterruptCollectorTest, GetLastMetrics) {
     collector_->collect();
     auto last = collector_->get_last_metrics();
 
-    // Timestamp should be set
-    auto now = std::chrono::system_clock::now();
-    auto diff = std::chrono::duration_cast<std::chrono::seconds>(now - last.timestamp);
-    EXPECT_LT(diff.count(), 10);  // Within 10 seconds
+    if (collector_->is_interrupt_monitoring_available()) {
+        // On platforms with interrupt monitoring, timestamp should be recent
+        auto now = std::chrono::system_clock::now();
+        auto diff = std::chrono::duration_cast<std::chrono::seconds>(now - last.timestamp);
+        EXPECT_LT(diff.count(), 10);  // Within 10 seconds
+    } else {
+        // On platforms without interrupt monitoring (e.g. Windows),
+        // last_metrics_ is never updated so metrics_available stays false
+        EXPECT_FALSE(last.metrics_available);
+    }
 }
 
 // Test is_interrupt_monitoring_available
@@ -180,7 +192,13 @@ TEST_F(InterruptCollectorTest, MultipleCollectionsAreStable) {
     }
 
     auto stats = collector_->get_statistics();
-    EXPECT_GE(stats["collection_count"], 10.0);
+    if (collector_->is_interrupt_monitoring_available()) {
+        EXPECT_GE(stats["collection_count"], 10.0);
+    } else {
+        // On platforms without interrupt monitoring (e.g. Windows),
+        // all collections fail gracefully
+        EXPECT_GE(stats["collection_errors"], 10.0);
+    }
 }
 
 // Test that metrics have correct tags when collected

--- a/tests/test_network_metrics_collector.cpp
+++ b/tests/test_network_metrics_collector.cpp
@@ -359,19 +359,22 @@ TEST(NetworkInfoCollectorTest, HasTcpConnectionsOnUnix) {
 #endif
 
 #if defined(_WIN32)
-// Platform-specific test: On Windows, monitoring is not yet implemented
+// Platform-specific test: On Windows, socket buffer monitoring is not available
+// but TCP state monitoring works via GetExtendedTcpTable()
 TEST_F(NetworkMetricsCollectorTest, WindowsNetworkMonitoringUnavailable) {
     EXPECT_FALSE(collector_->is_socket_buffer_monitoring_available());
-    EXPECT_FALSE(collector_->is_tcp_state_monitoring_available());
+    EXPECT_TRUE(collector_->is_tcp_state_monitoring_available());
 }
 
-// Platform-specific test: Windows metrics should indicate unavailability
+// Platform-specific test: Windows metrics reflect actual API availability
 TEST(NetworkInfoCollectorTest, WindowsReturnsUnavailableMetrics) {
     network_info_collector collector;
     network_metrics_config config;
     auto metrics = collector.collect_metrics(config);
+    // Socket buffers are not available on Windows
     EXPECT_FALSE(metrics.socket_buffer_available);
-    EXPECT_FALSE(metrics.tcp_state_available);
+    // TCP states are available via GetExtendedTcpTable()
+    EXPECT_TRUE(metrics.tcp_state_available);
 }
 #endif
 


### PR DESCRIPTION
## What

Fix 5 Windows platform test failures that pass on macOS/Ubuntu but fail on Windows MSVC 2022 CI runners.

### Failing Tests
- `NetworkMetricsCollectorTest.WindowsNetworkMonitoringUnavailable`
- `NetworkInfoCollectorTest.WindowsReturnsUnavailableMetrics`
- `InterruptCollectorTest.TracksStatistics`
- `InterruptCollectorTest.GetLastMetrics`
- `InterruptCollectorTest.MultipleCollectionsAreStable`

## Why

These failures block CI in downstream projects (e.g., messaging_system) that run monitoring_system tests as part of their build. The test expectations did not match the actual Windows platform behavior.

Closes #609

## Where

| File | Change |
|------|--------|
| `tests/test_network_metrics_collector.cpp` | Fix Windows-specific test expectations |
| `tests/test_interrupt_collector.cpp` | Add platform-aware branching in cross-platform tests |

## How

### Root Cause

**Network tests (2 failures):** The Windows-specific tests assumed both socket buffer and TCP state monitoring were unavailable. In reality, the Windows `metrics_provider` implements TCP state collection via `GetExtendedTcpTable()` (returning `available = true`), while only socket buffer stats are unavailable. The tests were written before the TCP state implementation was added.

**Interrupt tests (3 failures):** Three cross-platform tests (`TracksStatistics`, `GetLastMetrics`, `MultipleCollectionsAreStable`) assumed that `collect()` always succeeds. On Windows, interrupt monitoring is not implemented, so `collect()` returns `metrics_available = false`, which increments `collection_errors_` instead of `collection_count_`, and never updates `last_metrics_`.

### Fix

- **Network tests:** Updated `WindowsNetworkMonitoringUnavailable` and `WindowsReturnsUnavailableMetrics` to expect `is_tcp_state_monitoring_available() == true` and `tcp_state_available == true`, matching the actual Windows implementation.
- **Interrupt tests:** Added `is_interrupt_monitoring_available()` checks to branch test expectations: on platforms with monitoring, verify `collection_count`; on platforms without (Windows), verify `collection_errors` and `metrics_available == false`.

### Testing
- macOS/Linux: No behavioral change. `is_interrupt_monitoring_available()` returns `true`, so existing assertions still execute.
- Windows: Tests now validate the correct "unavailable" code path instead of asserting impossible conditions.