### PR TITLE
chore(ci): migrate to setup-vcpkg composite action for ecosystem CI standardization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,59 +134,17 @@ jobs:
           echo "VCPKG_FORCE_SYSTEM_BINARIES=arm" >> $GITHUB_ENV
         fi
 
-    - name: Cache vcpkg
-      uses: actions/cache@v5
-      id: vcpkg-cache
+    - name: Setup vcpkg
+      uses: kcenon/common_system/.github/actions/setup-vcpkg@main
       with:
-        path: |
-          ${{ github.workspace }}/vcpkg
-          !${{ github.workspace }}/vcpkg/buildtrees
-          !${{ github.workspace }}/vcpkg/packages
-          !${{ github.workspace }}/vcpkg/downloads
-        key: ${{ runner.os }}-${{ matrix.compiler }}-vcpkg-${{ hashFiles('vcpkg.json') }}
-
-    - name: Set up vcpkg (Unix)
-      if: runner.os != 'Windows'
-      run: |
-        if [ ! -d "vcpkg" ]; then
-          git clone https://github.com/Microsoft/vcpkg.git
-        fi
-        cd vcpkg
-        git pull
-        ./bootstrap-vcpkg.sh
-        cd ..
-
-    - name: Set up vcpkg (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        if (!(Test-Path "vcpkg")) {
-          git clone https://github.com/Microsoft/vcpkg.git
-        }
-        cd vcpkg
-        git pull
-        .\bootstrap-vcpkg.bat
-        cd ..
-
-    - name: Determine vcpkg commit (Unix)
-      if: runner.os != 'Windows'
-      id: vcpkg-commit-unix
-      run: echo "commit=$(git -C vcpkg rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-    - name: Determine vcpkg commit (Windows)
-      if: runner.os == 'Windows'
-      id: vcpkg-commit-windows
-      shell: pwsh
-      run: |
-        $commit = git -C vcpkg rev-parse HEAD
-        "commit=$commit" >> $env:GITHUB_OUTPUT
+        extra-cache-key: 'monitoring-system'
 
     - name: Cache vcpkg installed
       uses: actions/cache@v5
       id: vcpkg-installed
       with:
         path: ${{ github.workspace }}/vcpkg_installed
-        key: ${{ runner.os }}-${{ matrix.compiler }}-vcpkg-installed-${{ matrix.triplet }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}-${{ steps.vcpkg-commit-unix.outputs.commit || steps.vcpkg-commit-windows.outputs.commit }}
+        key: ${{ runner.os }}-${{ matrix.compiler }}-vcpkg-installed-${{ matrix.triplet }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.compiler }}-vcpkg-installed-${{ matrix.triplet }}-
 
@@ -194,14 +152,14 @@ jobs:
       if: runner.os != 'Windows' && steps.vcpkg-installed.outputs.cache-hit != 'true'
       continue-on-error: true
       run: |
-        ./vcpkg/vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}/vcpkg_installed --triplet ${{ matrix.triplet }}
+        ${{ env.VCPKG_ROOT }}/vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}/vcpkg_installed --triplet ${{ matrix.triplet }}
 
     - name: Install dependencies with vcpkg (Windows)
       if: runner.os == 'Windows' && steps.vcpkg-installed.outputs.cache-hit != 'true'
       continue-on-error: true
       shell: pwsh
       run: |
-        .\vcpkg\vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}\vcpkg_installed --triplet ${{ matrix.triplet }}
+        ${{ env.VCPKG_ROOT }}\vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}\vcpkg_installed --triplet ${{ matrix.triplet }}
 
     - name: Prepare build directory
       if: runner.os != 'Windows'
@@ -226,7 +184,7 @@ jobs:
           -G Ninja \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DBUILD_EXAMPLES=OFF \
-          -DCMAKE_TOOLCHAIN_FILE="${GITHUB_WORKSPACE}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+          -DCMAKE_TOOLCHAIN_FILE="${{ env.CMAKE_TOOLCHAIN_FILE }}" \
           -DCMAKE_C_COMPILER=${CMAKE_C_COMP} \
           -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMP}
 
@@ -247,7 +205,7 @@ jobs:
           -A x64 `
           -DCMAKE_BUILD_TYPE=$env:BUILD_TYPE `
           -DBUILD_EXAMPLES=OFF `
-          -DCMAKE_TOOLCHAIN_FILE="$env:GITHUB_WORKSPACE\vcpkg\scripts\buildsystems\vcpkg.cmake" `
+          -DCMAKE_TOOLCHAIN_FILE="${{ env.CMAKE_TOOLCHAIN_FILE }}" `
           -DCMAKE_CXX_FLAGS="/std:c++20 /permissive- /Zc:__cplusplus /EHsc" `
           -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY"
 

--- a/.github/workflows/validate-vcpkg-chain.yml
+++ b/.github/workflows/validate-vcpkg-chain.yml
@@ -43,9 +43,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: kcenon/common_system/.github/actions/setup-vcpkg@main
         with:
-          vcpkgGitCommitId: d90a9b159c08169f39adcd1b0f1ac0ca12c4b96c
+          extra-cache-key: 'monitoring-system'
 
       - name: Install GCC 13 (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary
- Replace `lukka/run-vcpkg@v11` in `validate-vcpkg-chain.yml` with `kcenon/common_system/.github/actions/setup-vcpkg@main`
- Replace inline vcpkg clone/bootstrap in `ci.yml` with the same composite action
- Standardize `CMAKE_TOOLCHAIN_FILE` and `VCPKG_ROOT` usage via env vars set by the composite action

## Why
Standardizes vcpkg setup across all ecosystem repositories using a single composite action that pins the vcpkg commit to the ecosystem baseline and provides consistent caching.

Part of kcenon/common_system#517

## Test plan
- [ ] CI build job passes on all platforms (ubuntu, macos, windows)
- [ ] CI fallback builds still work when vcpkg fails
- [ ] validate-vcpkg-chain workflow passes on all platforms
- [ ] vcpkg caching works correctly