### PR TITLE
chore(vcpkg): update registry baseline to 5716e4f

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "77cc46d5ba5e2aef1581f2ec674f83e1ac906b43",
+      "baseline": "5716e4f6b36108cebeacec52bbc42502dd1e9c48",
       "packages": [
         "kcenon-*"
       ]


### PR DESCRIPTION
## Summary
- Update vcpkg-registry baseline from `77cc46d` to `5716e4f` to pick up latest versions DB and baseline.json fixes

## Related Issues
Part of kcenon/common_system#528