### PR TITLE
chore(vcpkg): sync root manifest port-version and add local usage file

### DIFF
--- a/vcpkg-ports/kcenon-monitoring-system/usage
+++ b/vcpkg-ports/kcenon-monitoring-system/usage
@@ -1,0 +1,6 @@
+The package kcenon-monitoring-system provides CMake targets:
+
+    find_package(monitoring_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE monitoring_system::monitoring_system)
+
+Available features: logging, network, grpc

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-monitoring-system",
   "version-semver": "0.1.0",
-  "port-version": 0,
+  "port-version": 1,
   "description": "High-performance C++20 monitoring system with metrics, tracing, and alerting",
   "homepage": "https://github.com/kcenon/monitoring_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## Summary
- Sync root `vcpkg.json` port-version from 0 to 1
- Add missing `usage` file to local port directory

## Related
- Closes #627

## Test plan
- [ ] Verify root vcpkg.json port-version matches port definition
- [ ] Verify usage file is present