### PR TITLE
docs: add YAML frontmatter to all docs/ markdown files

### DIFF
--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-API-001"
+doc_title: "Monitoring System API 레퍼런스"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "API"
+---
+
 # Monitoring System API 레퍼런스
 
 > **Language:** [English](API_REFERENCE.md) | **한국어**

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-API-002"
+doc_title: "Monitoring System API Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "API"
+---
+
 # Monitoring System API Reference
 
 > **Language:** **English** | [한국어](API_REFERENCE.kr.md)

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-ARCH-001"
+doc_title: "Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "ARCH"
+---
+
 아키텍처 개요
 =====================
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-ARCH-002"
+doc_title: "Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "ARCH"
+---
+
 Architecture Overview
 =====================
 

--- a/docs/BENCHMARKS.kr.md
+++ b/docs/BENCHMARKS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-001"
+doc_title: "Monitoring System - 성능 벤치마크"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 # Monitoring System - 성능 벤치마크
 
 **언어:** [English](BENCHMARKS.md) | **한국어**

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-002"
+doc_title: "Monitoring System - Performance Benchmarks"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 # Monitoring System - Performance Benchmarks
 
 **Version**: 0.1.0.0

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PROJ-001"
+doc_title: "변경 로그"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PROJ"
+---
+
 # 변경 로그
 
 > **Language:** [English](CHANGELOG.md) | **한국어**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PROJ-002"
+doc_title: "Changelog"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PROJ"
+---
+
 # Changelog
 
 > **Language:** **English** | [한국어](CHANGELOG.kr.md)

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-FEAT-001"
+doc_title: "Monitoring System - 상세 기능"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "FEAT"
+---
+
 # Monitoring System - 상세 기능
 
 **언어:** [English](README.md) | **한국어**

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-FEAT-002"
+doc_title: "Monitoring System - Feature Documentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "FEAT"
+---
+
 # Monitoring System - Feature Documentation
 
 **Version**: 0.4.0.0

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-001"
+doc_title: "Known Issues and Limitations"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Known Issues and Limitations
 
 **Version**: 0.2.0.0

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-QUAL-001"
+doc_title: "Monitoring System - 프로덕션 품질 메트릭"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "QUAL"
+---
+
 # Monitoring System - 프로덕션 품질 메트릭
 
 **언어:** [English](PRODUCTION_QUALITY.md) | **한국어**

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-QUAL-002"
+doc_title: "Monitoring System - Production Quality Metrics"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "QUAL"
+---
+
 # Monitoring System - Production Quality Metrics
 
 **Version**: 0.1.0.0

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PROJ-003"
+doc_title: "Monitoring System - 프로젝트 구조"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PROJ"
+---
+
 # Monitoring System - 프로젝트 구조
 
 **언어:** [English](PROJECT_STRUCTURE.md) | **한국어**

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PROJ-004"
+doc_title: "Monitoring System - Project Structure"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PROJ"
+---
+
 # Monitoring System - Project Structure
 
 **Version**: 0.3.0.0

--- a/docs/README.kr.md
+++ b/docs/README.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-002"
+doc_title: "Monitoring System 문서"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Monitoring System 문서
 
 > **Language:** [English](README.md) | **한국어**

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-003"
+doc_title: "Monitoring System Documentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Monitoring System Documentation
 
 > **Language:** **English** | [한국어](README.kr.md)

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PROJ-005"
+doc_title: "SOUP List &mdash; monitoring_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PROJ"
+---
+
 # SOUP List &mdash; monitoring_system
 
 > **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**

--- a/docs/advanced/ARCHITECTURE.md
+++ b/docs/advanced/ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-ARCH-003"
+doc_title: "Architecture Overview"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "ARCH"
+---
+
 # Architecture Overview
 
 ## Purpose

--- a/docs/advanced/ARCHITECTURE_GUIDE.kr.md
+++ b/docs/advanced/ARCHITECTURE_GUIDE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-ARCH-004"
+doc_title: "Monitoring System 아키텍처 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "ARCH"
+---
+
 # Monitoring System 아키텍처 가이드
 
 > **Language:** [English](ARCHITECTURE_GUIDE.md) | **한국어**

--- a/docs/advanced/ARCHITECTURE_GUIDE.md
+++ b/docs/advanced/ARCHITECTURE_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-ARCH-005"
+doc_title: "Monitoring System Architecture Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "ARCH"
+---
+
 # Monitoring System Architecture Guide
 
 > **Language:** **English** | [한국어](ARCHITECTURE_GUIDE.kr.md)

--- a/docs/advanced/ARCHITECTURE_ISSUES.kr.md
+++ b/docs/advanced/ARCHITECTURE_ISSUES.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-ARCH-006"
+doc_title: "Architecture Issues - Phase 0 식별"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "ARCH"
+---
+
 # Architecture Issues - Phase 0 식별
 
 > **Language:** [English](ARCHITECTURE_ISSUES.md) | **한국어**

--- a/docs/advanced/ARCHITECTURE_ISSUES.md
+++ b/docs/advanced/ARCHITECTURE_ISSUES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-ARCH-007"
+doc_title: "Architecture Issues - Phase 0 Identification"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "ARCH"
+---
+
 # Architecture Issues - Phase 0 Identification
 
 > **Language:** **English** | [한국어](ARCHITECTURE_ISSUES.kr.md)

--- a/docs/advanced/CURRENT_STATE.kr.md
+++ b/docs/advanced/CURRENT_STATE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-004"
+doc_title: "시스템 현재 상태 - Phase 0 기준선"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # 시스템 현재 상태 - Phase 0 기준선
 
 > **Language:** [English](CURRENT_STATE.md) | **한국어**

--- a/docs/advanced/CURRENT_STATE.md
+++ b/docs/advanced/CURRENT_STATE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-005"
+doc_title: "System Current State - Phase 0 Baseline"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # System Current State - Phase 0 Baseline
 
 > **Language:** **English** | [한국어](CURRENT_STATE.kr.md)

--- a/docs/advanced/INTERFACE_SEPARATION_STRATEGY.md
+++ b/docs/advanced/INTERFACE_SEPARATION_STRATEGY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-ARCH-008"
+doc_title: "Interface Separation Strategy"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "ARCH"
+---
+
 # Interface Separation Strategy
 
 **Version**: 0.1.0.0

--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-MIGR-001"
+doc_title: "Migration Guide - Monitoring System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "MIGR"
+---
+
 # Migration Guide - Monitoring System
 
 > **Language:** **English** | [한국어](MIGRATION.kr.md)

--- a/docs/advanced/MIGRATION_GUIDE_V2.kr.md
+++ b/docs/advanced/MIGRATION_GUIDE_V2.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-MIGR-002"
+doc_title: "마이그레이션 가이드: 인터페이스 기반 아키텍처"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "MIGR"
+---
+
 # 마이그레이션 가이드: 인터페이스 기반 아키텍처
 
 > **Language:** [English](MIGRATION_GUIDE_V2.md) | **한국어**

--- a/docs/advanced/MIGRATION_GUIDE_V2.md
+++ b/docs/advanced/MIGRATION_GUIDE_V2.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-MIGR-003"
+doc_title: "Migration Guide: Interface-Based Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "MIGR"
+---
+
 # Migration Guide: Interface-Based Architecture
 
 > **Language:** **English** | [한국어](MIGRATION_GUIDE_V2.kr.md)

--- a/docs/advanced/PROFILING_GUIDE.md
+++ b/docs/advanced/PROFILING_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-003"
+doc_title: "Performance Profiling Guide for monitoring_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 # Performance Profiling Guide for monitoring_system
 
 **Date**: 2025-11-09

--- a/docs/advanced/STRUCTURE.kr.md
+++ b/docs/advanced/STRUCTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-ARCH-009"
+doc_title: "Monitoring System - 프로젝트 구조"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "ARCH"
+---
+
 # Monitoring System - 프로젝트 구조
 
 > **언어 선택 (Language)**: [English](STRUCTURE.md) | **한국어**

--- a/docs/advanced/STRUCTURE.md
+++ b/docs/advanced/STRUCTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-ARCH-010"
+doc_title: "Monitoring System - Project Structure"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "ARCH"
+---
+
 # Monitoring System - Project Structure
 
 > **Language**: **English** | [한국어](STRUCTURE.kr.md)

--- a/docs/advanced/THREAD_LOCAL_COLLECTOR_DESIGN.md
+++ b/docs/advanced/THREAD_LOCAL_COLLECTOR_DESIGN.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-ARCH-011"
+doc_title: "Thread-Local Collector Design"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "ARCH"
+---
+
 # Thread-Local Collector Design
 
 **Date**: 2025-11-09

--- a/docs/contributing/CI_CD_GUIDE.md
+++ b/docs/contributing/CI_CD_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-006"
+doc_title: "CI/CD Guide for Monitoring System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # CI/CD Guide for Monitoring System
 
 > **Version:** 0.1.0

--- a/docs/contributing/CONTRIBUTING.kr.md
+++ b/docs/contributing/CONTRIBUTING.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PROJ-006"
+doc_title: "Monitoring System에 기여하기"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PROJ"
+---
+
 # Monitoring System에 기여하기
 
 > **Language:** [English](CONTRIBUTING.md) | **한국어**

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PROJ-007"
+doc_title: "Contributing to Monitoring System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PROJ"
+---
+
 # Contributing to Monitoring System
 
 > **Language:** **English** | [한국어](CONTRIBUTING.kr.md)

--- a/docs/contributing/TESTING_GUIDE.md
+++ b/docs/contributing/TESTING_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-QUAL-003"
+doc_title: "Testing Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "QUAL"
+---
+
 ## Test Coverage
 
 To enable code coverage measurement:

--- a/docs/guides/ADVANCED_ALERTS.md
+++ b/docs/guides/ADVANCED_ALERTS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-007"
+doc_title: "Advanced Alert Configuration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Advanced Alert Configuration Guide
 
 > **Version**: 0.1.0

--- a/docs/guides/ALERT_PIPELINE.md
+++ b/docs/guides/ALERT_PIPELINE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-008"
+doc_title: "Alert Pipeline Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Alert Pipeline Guide
 
 This guide covers the alert pipeline feature, enabling automated alerting based on metric thresholds, patterns, and anomalies.

--- a/docs/guides/BEST_PRACTICES.md
+++ b/docs/guides/BEST_PRACTICES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-009"
+doc_title: "Monitoring System - Best Practices Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Monitoring System - Best Practices Guide
 
 > **Version:** 0.1.0

--- a/docs/guides/COLLECTOR_DEVELOPMENT.md
+++ b/docs/guides/COLLECTOR_DEVELOPMENT.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-010"
+doc_title: "Collector Development Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Collector Development Guide
 
 > **Language:** **English** | [한국어](COLLECTOR_DEVELOPMENT.kr.md)

--- a/docs/guides/DISTRIBUTED_TRACING.md
+++ b/docs/guides/DISTRIBUTED_TRACING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-INTR-001"
+doc_title: "Distributed Tracing Deep Dive Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "INTR"
+---
+
 # Distributed Tracing Deep Dive Guide
 
 > **Version**: 0.1.0

--- a/docs/guides/DI_AND_CONCEPTS.md
+++ b/docs/guides/DI_AND_CONCEPTS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-API-003"
+doc_title: "DI Container and C++20 Concepts Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "API"
+---
+
 # DI Container and C++20 Concepts Guide
 
 > **Language:** **English** | Advanced Guide

--- a/docs/guides/EXPORTER_DEVELOPMENT.md
+++ b/docs/guides/EXPORTER_DEVELOPMENT.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-011"
+doc_title: "Exporter Development Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Exporter Development Guide
 
 > **Version**: 1.0.0

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-012"
+doc_title: "Monitoring System - Frequently Asked Questions"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Monitoring System - Frequently Asked Questions
 
 > **Version:** 0.1.0

--- a/docs/guides/INTEGRATION.md
+++ b/docs/guides/INTEGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-INTR-002"
+doc_title: "Integration Guide - Monitoring System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "INTR"
+---
+
 # Integration Guide - Monitoring System
 
 > **Language:** **English** | [한국어](INTEGRATION.kr.md)

--- a/docs/guides/NAMESPACE_MIGRATION.kr.md
+++ b/docs/guides/NAMESPACE_MIGRATION.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-MIGR-004"
+doc_title: "네임스페이스 마이그레이션 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "MIGR"
+---
+
 # 네임스페이스 마이그레이션 가이드
 
 > **버전:** 1.0.0

--- a/docs/guides/NAMESPACE_MIGRATION.md
+++ b/docs/guides/NAMESPACE_MIGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-MIGR-005"
+doc_title: "Namespace Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "MIGR"
+---
+
 # Namespace Migration Guide
 
 > **Version:** 1.0.0

--- a/docs/guides/OTEL_COLLECTOR_SIDECAR.kr.md
+++ b/docs/guides/OTEL_COLLECTOR_SIDECAR.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-INTR-003"
+doc_title: "OpenTelemetry Collector 사이드카 패턴"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "INTR"
+---
+
 # OpenTelemetry Collector 사이드카 패턴
 
 > **Language:** [English](OTEL_COLLECTOR_SIDECAR.md) | **한국어**

--- a/docs/guides/OTEL_COLLECTOR_SIDECAR.md
+++ b/docs/guides/OTEL_COLLECTOR_SIDECAR.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-INTR-004"
+doc_title: "OpenTelemetry Collector Sidecar Pattern"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "INTR"
+---
+
 # OpenTelemetry Collector Sidecar Pattern
 
 > **Language:** **English** | [한국어](OTEL_COLLECTOR_SIDECAR.kr.md)

--- a/docs/guides/PERFORMANCE_COOKBOOK.md
+++ b/docs/guides/PERFORMANCE_COOKBOOK.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-004"
+doc_title: "Performance Optimization Cookbook"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 # Performance Optimization Cookbook
 
 > **Language:** **English** | Advanced Guide

--- a/docs/guides/PORT_MANAGEMENT.md
+++ b/docs/guides/PORT_MANAGEMENT.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-013"
+doc_title: "vcpkg Port Management"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # vcpkg Port Management
 
 This document defines the authoritative port management strategy for the kcenon

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-014"
+doc_title: "Monitoring System - 빠른 시작 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Monitoring System - 빠른 시작 가이드
 
 > **Language:** [English](QUICK_START.md) | **한국어**

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-015"
+doc_title: "Monitoring System - Quick Start Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Monitoring System - Quick Start Guide
 
 > **Version:** 0.1.0

--- a/docs/guides/RELIABILITY_PATTERNS.md
+++ b/docs/guides/RELIABILITY_PATTERNS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-QUAL-004"
+doc_title: "Reliability Patterns Usage Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "QUAL"
+---
+
 # Reliability Patterns Usage Guide
 
 > **Version**: 1.0.0

--- a/docs/guides/SECURITY.kr.md
+++ b/docs/guides/SECURITY.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-SECU-001"
+doc_title: "보안 정책"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "SECU"
+---
+
 # 보안 정책
 
 > **Language:** [English](SECURITY.md) | **한국어**

--- a/docs/guides/SECURITY.md
+++ b/docs/guides/SECURITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-SECU-002"
+doc_title: "Security Policy"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "SECU"
+---
+
 # Security Policy
 
 > **Language:** **English** | [한국어](SECURITY.kr.md)

--- a/docs/guides/STORAGE_BACKENDS.md
+++ b/docs/guides/STORAGE_BACKENDS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-016"
+doc_title: "Storage Backend Implementation Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Storage Backend Implementation Guide
 
 > **Version**: 1.0.0

--- a/docs/guides/STREAM_PROCESSING.md
+++ b/docs/guides/STREAM_PROCESSING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-017"
+doc_title: "Stream Processing and Aggregation Framework"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Stream Processing and Aggregation Framework
 
 > **Version**: 0.1.0

--- a/docs/guides/TROUBLESHOOTING.kr.md
+++ b/docs/guides/TROUBLESHOOTING.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-018"
+doc_title: "문제 해결 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # 문제 해결 가이드
 
 > **Language:** [English](TROUBLESHOOTING.md) | **한국어**

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-019"
+doc_title: "Troubleshooting Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Troubleshooting Guide
 
 > **Language:** **English** | [한국어](TROUBLESHOOTING.kr.md)

--- a/docs/guides/TUTORIAL.kr.md
+++ b/docs/guides/TUTORIAL.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-020"
+doc_title: "Monitoring System 튜토리얼"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Monitoring System 튜토리얼
 
 > **Language:** [English](TUTORIAL.md) | **한국어**

--- a/docs/guides/TUTORIAL.md
+++ b/docs/guides/TUTORIAL.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-021"
+doc_title: "Monitoring System Tutorial"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Monitoring System Tutorial
 
 > **Language:** **English** | [한국어](TUTORIAL.kr.md)

--- a/docs/guides/VCPKG_OVERLAY_PORTS.md
+++ b/docs/guides/VCPKG_OVERLAY_PORTS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-022"
+doc_title: "vcpkg Overlay Ports Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # vcpkg Overlay Ports Guide
 
 This guide explains how to use the vcpkg overlay ports provided by the

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-023"
+doc_title: "Monitoring System Integration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Monitoring System Integration Guide
 
 ## Overview

--- a/docs/performance/BASELINE.kr.md
+++ b/docs/performance/BASELINE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-005"
+doc_title: "Monitoring System - 성능 기준 메트릭"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 <<<<<<< HEAD
 # Monitoring System - 성능 기준 메트릭
 

--- a/docs/performance/BASELINE.md
+++ b/docs/performance/BASELINE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-006"
+doc_title: "Baseline Performance Metrics"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 # Baseline Performance Metrics
 
 **Document Version**: 3.0

--- a/docs/performance/PERFORMANCE_BASELINE.md
+++ b/docs/performance/PERFORMANCE_BASELINE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-007"
+doc_title: "Performance Baseline Measurements"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 # Performance Baseline Measurements
 
 **Date**: 2025-11-08

--- a/docs/performance/PERFORMANCE_TUNING.kr.md
+++ b/docs/performance/PERFORMANCE_TUNING.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-008"
+doc_title: "성능 튜닝 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 # 성능 튜닝 가이드
 
 > **Language:** [English](PERFORMANCE_TUNING.md) | **한국어**

--- a/docs/performance/PERFORMANCE_TUNING.md
+++ b/docs/performance/PERFORMANCE_TUNING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-009"
+doc_title: "Performance Tuning Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 # Performance Tuning Guide
 
 > **Language:** **English** | [한국어](PERFORMANCE_TUNING.kr.md)

--- a/docs/performance/SANITIZER_BASELINE.kr.md
+++ b/docs/performance/SANITIZER_BASELINE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-010"
+doc_title: "monitoring_system Sanitizer 기준선"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 # monitoring_system Sanitizer 기준선
 
 > **Language:** [English](SANITIZER_BASELINE.md) | **한국어**

--- a/docs/performance/SANITIZER_BASELINE.md
+++ b/docs/performance/SANITIZER_BASELINE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-011"
+doc_title: "monitoring_system Sanitizer Baseline"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 # monitoring_system Sanitizer Baseline
 
 > **Language:** **English** | [한국어](SANITIZER_BASELINE.kr.md)

--- a/docs/performance/SPRINT_2_PERFORMANCE_RESULTS.md
+++ b/docs/performance/SPRINT_2_PERFORMANCE_RESULTS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-012"
+doc_title: "Sprint 2 Performance Verification Results"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 # Sprint 2 Performance Verification Results
 
 **Date**: 2025-11-09

--- a/docs/performance/STATIC_ANALYSIS_BASELINE.kr.md
+++ b/docs/performance/STATIC_ANALYSIS_BASELINE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-013"
+doc_title: "정적 분석 기준선 - monitoring_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 # 정적 분석 기준선 - monitoring_system
 
 > **Language:** [English](STATIC_ANALYSIS_BASELINE.md) | **한국어**

--- a/docs/performance/STATIC_ANALYSIS_BASELINE.md
+++ b/docs/performance/STATIC_ANALYSIS_BASELINE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-PERF-014"
+doc_title: "Static Analysis Baseline - monitoring_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "PERF"
+---
+
 # Static Analysis Baseline - monitoring_system
 
 > **Language:** **English** | [한국어](STATIC_ANALYSIS_BASELINE.kr.md)

--- a/docs/plugin_api_reference.md
+++ b/docs/plugin_api_reference.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-API-004"
+doc_title: "Plugin API Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "API"
+---
+
 # Plugin API Reference
 
 Complete reference for the collector plugin API.

--- a/docs/plugin_architecture.md
+++ b/docs/plugin_architecture.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-ARCH-012"
+doc_title: "Collector Plugin Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "ARCH"
+---
+
 # Collector Plugin Architecture
 
 ## Overview

--- a/docs/plugin_development_guide.md
+++ b/docs/plugin_development_guide.md
@@ -1,3 +1,13 @@
+---
+doc_id: "MON-GUID-024"
+doc_title: "Plugin Development Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "monitoring_system"
+category: "GUID"
+---
+
 # Plugin Development Guide
 
 ## Table of Contents


### PR DESCRIPTION
Part of kcenon/common_system#562

## Summary
- Add standardized YAML frontmatter metadata to 78 markdown files in `docs/`
- Each file gets a unique `doc_id` (`MON-{CATEGORY}-{NNN}`), title, version, date, status, project, and category

## Category Breakdown (78 files)
| Category | Count | Description |
|----------|-------|-------------|
| API | 4 | API Reference |
| ARCH | 12 | Architecture |
| FEAT | 2 | Features |
| GUID | 24 | User Guides |
| INTR | 4 | Integration |
| MIGR | 5 | Migration |
| PERF | 14 | Performance |
| PROJ | 7 | Project Info |
| QUAL | 4 | Quality |
| SECU | 2 | Security |

## Test Plan
- [x] Script runs idempotently (re-running skips all files)
- [x] No duplicate doc_id values
- [x] Existing document content unchanged (frontmatter prepended only)