### PR TITLE
docs: add SSOT documentation registry

### DIFF
--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -10,6 +10,8 @@ category: "API"
 
 # Monitoring System API 레퍼런스
 
+> **SSOT**: This document is the single source of truth for **Monitoring System API 레퍼런스**.
+
 > **Language:** [English](API_REFERENCE.md) | **한국어**
 
 **Phase 4 - 현재 구현 상태**

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -10,6 +10,8 @@ category: "API"
 
 # Monitoring System API Reference
 
+> **SSOT**: This document is the single source of truth for **Monitoring System API Reference**.
+
 > **Language:** **English** | [한국어](API_REFERENCE.kr.md)
 
 **Phase 4 - Current Implementation Status**

--- a/docs/BENCHMARKS.kr.md
+++ b/docs/BENCHMARKS.kr.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Monitoring System - 성능 벤치마크
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - 성능 벤치마크**.
+
 **언어:** [English](BENCHMARKS.md) | **한국어**
 
 **버전**: 0.1.0

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Monitoring System - Performance Benchmarks
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - Performance Benchmarks**.
+
 **Version**: 0.1.0.0
 **Last Updated**: 2025-11-15
 **Platform**: Apple M1 (8-core) @ 3.2GHz, 16GB RAM, macOS Sonoma

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # 변경 로그
 
+> **SSOT**: This document is the single source of truth for **변경 로그**.
+
 > **Language:** [English](CHANGELOG.md) | **한국어**
 
 ## 목차

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Changelog
 
+> **SSOT**: This document is the single source of truth for **Changelog**.
+
 > **Language:** **English** | [한국어](CHANGELOG.kr.md)
 
 ## Table of Contents

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -10,6 +10,8 @@ category: "FEAT"
 
 # Monitoring System - 상세 기능
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - 상세 기능**.
+
 **언어:** [English](README.md) | **한국어**
 
 **최종 업데이트**: 2026-02-08

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -10,6 +10,8 @@ category: "FEAT"
 
 # Monitoring System - Feature Documentation
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - Feature Documentation**.
+
 **Version**: 0.4.0.0
 **Last Updated**: 2026-02-08
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Known Issues and Limitations
 
+> **SSOT**: This document is the single source of truth for **Known Issues and Limitations**.
+
 **Version**: 0.2.0.0
 **Last Updated**: 2026-01-09
 

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Monitoring System - 프로덕션 품질 메트릭
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - 프로덕션 품질 메트릭**.
+
 **언어:** [English](PRODUCTION_QUALITY.md) | **한국어**
 
 **버전**: 0.1.0

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Monitoring System - Production Quality Metrics
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - Production Quality Metrics**.
+
 **Version**: 0.1.0.0
 **Last Updated**: 2025-11-15
 **Grade**: **A** (Production Ready)

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Monitoring System - 프로젝트 구조
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - 프로젝트 구조**.
+
 **언어:** [English](PROJECT_STRUCTURE.md) | **한국어**
 
 **버전**: 0.3.0

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Monitoring System - Project Structure
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - Project Structure**.
+
 **Version**: 0.3.0.0
 **Last Updated**: 2026-01-22
 

--- a/docs/README.kr.md
+++ b/docs/README.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Monitoring System 문서
 
+> **SSOT**: This document is the single source of truth for **Monitoring System 문서**.
+
 > **Language:** [English](README.md) | **한국어**
 
 Monitoring System - C++ 애플리케이션을 위한 개발 중인 모니터링 및 관찰성 플랫폼의 포괄적인 문서에 오신 것을 환영합니다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 doc_id: "MON-GUID-003"
-doc_title: "Monitoring System Documentation"
+doc_title: "Monitoring System Documentation Registry"
 doc_version: "1.0.0"
 doc_date: "2026-04-04"
 doc_status: "Released"
@@ -8,324 +8,224 @@ project: "monitoring_system"
 category: "GUID"
 ---
 
-# Monitoring System Documentation
+# Monitoring System — Documentation Registry
 
-> **Language:** **English** | [한국어](README.kr.md)
+> **SSOT**: This file is the single source of truth for the documentation index
+> of **monitoring_system**.
 
-**Version:** 0.1.0
-**Last Updated:** 2025-11-11
-**Status:** Comprehensive
+Total documents: **77**
 
-Welcome to the monitoring_system documentation! This observability platform provides metrics collection, distributed tracing, real-time alerting, and interactive dashboards for C++20 applications.
+## Document Index
 
----
+| # | doc_id | Topic | Authority Document | Status |
+|---|--------|-------|-------------------|--------|
+| 1 | MON-ARCH-001 | Architecture | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
+| 2 | MON-ARCH-002 | Architecture | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
+| 3 | MON-ARCH-003 | Architecture Overview | [ARCHITECTURE.md](./advanced/ARCHITECTURE.md) | Released |
+| 4 | MON-ARCH-004 | Monitoring System 아키텍처 가이드 | [ARCHITECTURE_GUIDE.kr.md](./advanced/ARCHITECTURE_GUIDE.kr.md) | Released |
+| 5 | MON-ARCH-005 | Monitoring System Architecture Guide | [ARCHITECTURE_GUIDE.md](./advanced/ARCHITECTURE_GUIDE.md) | Released |
+| 6 | MON-ARCH-006 | Architecture Issues - Phase 0 식별 | [ARCHITECTURE_ISSUES.kr.md](./advanced/ARCHITECTURE_ISSUES.kr.md) | Released |
+| 7 | MON-ARCH-007 | Architecture Issues - Phase 0 Identification | [ARCHITECTURE_ISSUES.md](./advanced/ARCHITECTURE_ISSUES.md) | Released |
+| 8 | MON-ARCH-008 | Interface Separation Strategy | [INTERFACE_SEPARATION_STRATEGY.md](./advanced/INTERFACE_SEPARATION_STRATEGY.md) | Released |
+| 9 | MON-ARCH-009 | Monitoring System - 프로젝트 구조 | [STRUCTURE.kr.md](./advanced/STRUCTURE.kr.md) | Released |
+| 10 | MON-ARCH-010 | Monitoring System - Project Structure | [STRUCTURE.md](./advanced/STRUCTURE.md) | Released |
+| 11 | MON-ARCH-011 | Thread-Local Collector Design | [THREAD_LOCAL_COLLECTOR_DESIGN.md](./advanced/THREAD_LOCAL_COLLECTOR_DESIGN.md) | Released |
+| 12 | MON-ARCH-012 | Collector Plugin Architecture | [plugin_architecture.md](./plugin_architecture.md) | Released |
+| 13 | MON-API-001 | Monitoring System API 레퍼런스 | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
+| 14 | MON-API-002 | Monitoring System API Reference | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
+| 15 | MON-API-003 | DI Container and C++20 Concepts Guide | [DI_AND_CONCEPTS.md](./guides/DI_AND_CONCEPTS.md) | Released |
+| 16 | MON-API-004 | Plugin API Reference | [plugin_api_reference.md](./plugin_api_reference.md) | Released |
+| 17 | MON-FEAT-001 | Monitoring System - 상세 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
+| 18 | MON-FEAT-002 | Monitoring System - Feature Documentation | [FEATURES.md](./FEATURES.md) | Released |
+| 19 | MON-GUID-001 | Known Issues and Limitations | [KNOWN_ISSUES.md](./KNOWN_ISSUES.md) | Released |
+| 20 | MON-GUID-002 | Monitoring System 문서 | [README.kr.md](./README.kr.md) | Released |
+| 21 | MON-GUID-004 | 시스템 현재 상태 - Phase 0 기준선 | [CURRENT_STATE.kr.md](./advanced/CURRENT_STATE.kr.md) | Released |
+| 22 | MON-GUID-005 | System Current State - Phase 0 Baseline | [CURRENT_STATE.md](./advanced/CURRENT_STATE.md) | Released |
+| 23 | MON-GUID-006 | CI/CD Guide for Monitoring System | [CI_CD_GUIDE.md](./contributing/CI_CD_GUIDE.md) | Released |
+| 24 | MON-GUID-007 | Advanced Alert Configuration Guide | [ADVANCED_ALERTS.md](./guides/ADVANCED_ALERTS.md) | Released |
+| 25 | MON-GUID-008 | Alert Pipeline Guide | [ALERT_PIPELINE.md](./guides/ALERT_PIPELINE.md) | Released |
+| 26 | MON-GUID-009 | Monitoring System - Best Practices Guide | [BEST_PRACTICES.md](./guides/BEST_PRACTICES.md) | Released |
+| 27 | MON-GUID-010 | Collector Development Guide | [COLLECTOR_DEVELOPMENT.md](./guides/COLLECTOR_DEVELOPMENT.md) | Released |
+| 28 | MON-GUID-011 | Exporter Development Guide | [EXPORTER_DEVELOPMENT.md](./guides/EXPORTER_DEVELOPMENT.md) | Released |
+| 29 | MON-GUID-012 | Monitoring System - Frequently Asked Questions | [FAQ.md](./guides/FAQ.md) | Released |
+| 30 | MON-GUID-013 | vcpkg Port Management | [PORT_MANAGEMENT.md](./guides/PORT_MANAGEMENT.md) | Released |
+| 31 | MON-GUID-014 | Monitoring System - 빠른 시작 가이드 | [QUICK_START.kr.md](./guides/QUICK_START.kr.md) | Released |
+| 32 | MON-GUID-015 | Monitoring System - Quick Start Guide | [QUICK_START.md](./guides/QUICK_START.md) | Released |
+| 33 | MON-GUID-016 | Storage Backend Implementation Guide | [STORAGE_BACKENDS.md](./guides/STORAGE_BACKENDS.md) | Released |
+| 34 | MON-GUID-017 | Stream Processing and Aggregation Framework | [STREAM_PROCESSING.md](./guides/STREAM_PROCESSING.md) | Released |
+| 35 | MON-GUID-018 | 문제 해결 가이드 | [TROUBLESHOOTING.kr.md](./guides/TROUBLESHOOTING.kr.md) | Released |
+| 36 | MON-GUID-019 | Troubleshooting Guide | [TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
+| 37 | MON-GUID-020 | Monitoring System 튜토리얼 | [TUTORIAL.kr.md](./guides/TUTORIAL.kr.md) | Released |
+| 38 | MON-GUID-021 | Monitoring System Tutorial | [TUTORIAL.md](./guides/TUTORIAL.md) | Released |
+| 39 | MON-GUID-022 | vcpkg Overlay Ports Guide | [VCPKG_OVERLAY_PORTS.md](./guides/VCPKG_OVERLAY_PORTS.md) | Released |
+| 40 | MON-GUID-023 | Monitoring System Integration Guide | [README.md](./integration/README.md) | Released |
+| 41 | MON-GUID-024 | Plugin Development Guide | [plugin_development_guide.md](./plugin_development_guide.md) | Released |
+| 42 | MON-PERF-001 | Monitoring System - 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| 43 | MON-PERF-002 | Monitoring System - Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| 44 | MON-PERF-003 | Performance Profiling Guide for monitoring_system | [PROFILING_GUIDE.md](./advanced/PROFILING_GUIDE.md) | Released |
+| 45 | MON-PERF-004 | Performance Optimization Cookbook | [PERFORMANCE_COOKBOOK.md](./guides/PERFORMANCE_COOKBOOK.md) | Released |
+| 46 | MON-PERF-005 | Monitoring System - 성능 기준 메트릭 | [BASELINE.kr.md](./performance/BASELINE.kr.md) | Released |
+| 47 | MON-PERF-006 | Baseline Performance Metrics | [BASELINE.md](./performance/BASELINE.md) | Released |
+| 48 | MON-PERF-007 | Performance Baseline Measurements | [PERFORMANCE_BASELINE.md](./performance/PERFORMANCE_BASELINE.md) | Released |
+| 49 | MON-PERF-008 | 성능 튜닝 가이드 | [PERFORMANCE_TUNING.kr.md](./performance/PERFORMANCE_TUNING.kr.md) | Released |
+| 50 | MON-PERF-009 | Performance Tuning Guide | [PERFORMANCE_TUNING.md](./performance/PERFORMANCE_TUNING.md) | Released |
+| 51 | MON-PERF-010 | monitoring_system Sanitizer 기준선 | [SANITIZER_BASELINE.kr.md](./performance/SANITIZER_BASELINE.kr.md) | Released |
+| 52 | MON-PERF-011 | monitoring_system Sanitizer Baseline | [SANITIZER_BASELINE.md](./performance/SANITIZER_BASELINE.md) | Released |
+| 53 | MON-PERF-012 | Sprint 2 Performance Verification Results | [SPRINT_2_PERFORMANCE_RESULTS.md](./performance/SPRINT_2_PERFORMANCE_RESULTS.md) | Released |
+| 54 | MON-PERF-013 | 정적 분석 기준선 - monitoring_system | [STATIC_ANALYSIS_BASELINE.kr.md](./performance/STATIC_ANALYSIS_BASELINE.kr.md) | Released |
+| 55 | MON-PERF-014 | Static Analysis Baseline - monitoring_system | [STATIC_ANALYSIS_BASELINE.md](./performance/STATIC_ANALYSIS_BASELINE.md) | Released |
+| 56 | MON-MIGR-001 | Migration Guide - Monitoring System | [MIGRATION.md](./advanced/MIGRATION.md) | Released |
+| 57 | MON-MIGR-002 | 마이그레이션 가이드: 인터페이스 기반 아키텍처 | [MIGRATION_GUIDE_V2.kr.md](./advanced/MIGRATION_GUIDE_V2.kr.md) | Released |
+| 58 | MON-MIGR-003 | Migration Guide: Interface-Based Architecture | [MIGRATION_GUIDE_V2.md](./advanced/MIGRATION_GUIDE_V2.md) | Released |
+| 59 | MON-MIGR-004 | 네임스페이스 마이그레이션 가이드 | [NAMESPACE_MIGRATION.kr.md](./guides/NAMESPACE_MIGRATION.kr.md) | Released |
+| 60 | MON-MIGR-005 | Namespace Migration Guide | [NAMESPACE_MIGRATION.md](./guides/NAMESPACE_MIGRATION.md) | Released |
+| 61 | MON-INTR-001 | Distributed Tracing Deep Dive Guide | [DISTRIBUTED_TRACING.md](./guides/DISTRIBUTED_TRACING.md) | Released |
+| 62 | MON-INTR-002 | Integration Guide - Monitoring System | [INTEGRATION.md](./guides/INTEGRATION.md) | Released |
+| 63 | MON-INTR-003 | OpenTelemetry Collector 사이드카 패턴 | [OTEL_COLLECTOR_SIDECAR.kr.md](./guides/OTEL_COLLECTOR_SIDECAR.kr.md) | Released |
+| 64 | MON-INTR-004 | OpenTelemetry Collector Sidecar Pattern | [OTEL_COLLECTOR_SIDECAR.md](./guides/OTEL_COLLECTOR_SIDECAR.md) | Released |
+| 65 | MON-QUAL-001 | Monitoring System - 프로덕션 품질 메트릭 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
+| 66 | MON-QUAL-002 | Monitoring System - Production Quality Metrics | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
+| 67 | MON-QUAL-003 | Testing Guide | [TESTING_GUIDE.md](./contributing/TESTING_GUIDE.md) | Released |
+| 68 | MON-QUAL-004 | Reliability Patterns Usage Guide | [RELIABILITY_PATTERNS.md](./guides/RELIABILITY_PATTERNS.md) | Released |
+| 69 | MON-SECU-001 | 보안 정책 | [SECURITY.kr.md](./guides/SECURITY.kr.md) | Released |
+| 70 | MON-SECU-002 | Security Policy | [SECURITY.md](./guides/SECURITY.md) | Released |
+| 71 | MON-PROJ-001 | 변경 로그 | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| 72 | MON-PROJ-002 | Changelog | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| 73 | MON-PROJ-003 | Monitoring System - 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| 74 | MON-PROJ-004 | Monitoring System - Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| 75 | MON-PROJ-005 | SOUP List &mdash; monitoring_system | [SOUP.md](./SOUP.md) | Released |
+| 76 | MON-PROJ-006 | Monitoring System에 기여하기 | [CONTRIBUTING.kr.md](./contributing/CONTRIBUTING.kr.md) | Released |
+| 77 | MON-PROJ-007 | Contributing to Monitoring System | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
 
-## 🚀 Quick Navigation
+## Documents by Category
 
-| I want to... | Document |
-|--------------|----------|
-| ⚡ Get started in 5 minutes | [Quick Start](guides/QUICK_START.md) |
-| 🏗️ Understand the architecture | [Architecture](01-ARCHITECTURE.md) |
-| 📖 Look up an API | [API Reference](02-API_REFERENCE.md) |
-| ❓ Find answers to common questions | [FAQ](guides/FAQ.md) (25+ Q&A) |
-| 🐛 Troubleshoot an issue | [Troubleshooting](guides/TROUBLESHOOTING.md) |
-| ✨ Learn best practices | [Best Practices](guides/BEST_PRACTICES.md) |
-| 📊 Review performance benchmarks | [Baseline](performance/BASELINE.md) |
-| 🤝 Contribute to the project | [Contributing](contributing/CONTRIBUTING.md) |
+### Architecture (12)
 
----
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| MON-ARCH-001 | Architecture | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
+| MON-ARCH-002 | Architecture | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
+| MON-ARCH-003 | Architecture Overview | [ARCHITECTURE.md](./advanced/ARCHITECTURE.md) | Released |
+| MON-ARCH-004 | Monitoring System 아키텍처 가이드 | [ARCHITECTURE_GUIDE.kr.md](./advanced/ARCHITECTURE_GUIDE.kr.md) | Released |
+| MON-ARCH-005 | Monitoring System Architecture Guide | [ARCHITECTURE_GUIDE.md](./advanced/ARCHITECTURE_GUIDE.md) | Released |
+| MON-ARCH-006 | Architecture Issues - Phase 0 식별 | [ARCHITECTURE_ISSUES.kr.md](./advanced/ARCHITECTURE_ISSUES.kr.md) | Released |
+| MON-ARCH-007 | Architecture Issues - Phase 0 Identification | [ARCHITECTURE_ISSUES.md](./advanced/ARCHITECTURE_ISSUES.md) | Released |
+| MON-ARCH-008 | Interface Separation Strategy | [INTERFACE_SEPARATION_STRATEGY.md](./advanced/INTERFACE_SEPARATION_STRATEGY.md) | Released |
+| MON-ARCH-009 | Monitoring System - 프로젝트 구조 | [STRUCTURE.kr.md](./advanced/STRUCTURE.kr.md) | Released |
+| MON-ARCH-010 | Monitoring System - Project Structure | [STRUCTURE.md](./advanced/STRUCTURE.md) | Released |
+| MON-ARCH-011 | Thread-Local Collector Design | [THREAD_LOCAL_COLLECTOR_DESIGN.md](./advanced/THREAD_LOCAL_COLLECTOR_DESIGN.md) | Released |
+| MON-ARCH-012 | Collector Plugin Architecture | [plugin_architecture.md](./plugin_architecture.md) | Released |
 
-## Table of Contents
+### API Reference (4)
 
-- [Documentation Structure](#documentation-structure)
-- [Documentation by Role](#documentation-by-role)
-- [By Feature](#by-feature)
-- [Contributing to Documentation](#contributing-to-documentation)
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| MON-API-001 | Monitoring System API 레퍼런스 | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
+| MON-API-002 | Monitoring System API Reference | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
+| MON-API-003 | DI Container and C++20 Concepts Guide | [DI_AND_CONCEPTS.md](./guides/DI_AND_CONCEPTS.md) | Released |
+| MON-API-004 | Plugin API Reference | [plugin_api_reference.md](./plugin_api_reference.md) | Released |
 
----
+### Features (2)
 
-## Documentation Structure
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| MON-FEAT-001 | Monitoring System - 상세 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
+| MON-FEAT-002 | Monitoring System - Feature Documentation | [FEATURES.md](./FEATURES.md) | Released |
 
-### 📘 Core Documentation
+### Guides (23)
 
-Essential documents for understanding the system:
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| MON-GUID-001 | Known Issues and Limitations | [KNOWN_ISSUES.md](./KNOWN_ISSUES.md) | Released |
+| MON-GUID-002 | Monitoring System 문서 | [README.kr.md](./README.kr.md) | Released |
+| MON-GUID-004 | 시스템 현재 상태 - Phase 0 기준선 | [CURRENT_STATE.kr.md](./advanced/CURRENT_STATE.kr.md) | Released |
+| MON-GUID-005 | System Current State - Phase 0 Baseline | [CURRENT_STATE.md](./advanced/CURRENT_STATE.md) | Released |
+| MON-GUID-006 | CI/CD Guide for Monitoring System | [CI_CD_GUIDE.md](./contributing/CI_CD_GUIDE.md) | Released |
+| MON-GUID-007 | Advanced Alert Configuration Guide | [ADVANCED_ALERTS.md](./guides/ADVANCED_ALERTS.md) | Released |
+| MON-GUID-008 | Alert Pipeline Guide | [ALERT_PIPELINE.md](./guides/ALERT_PIPELINE.md) | Released |
+| MON-GUID-009 | Monitoring System - Best Practices Guide | [BEST_PRACTICES.md](./guides/BEST_PRACTICES.md) | Released |
+| MON-GUID-010 | Collector Development Guide | [COLLECTOR_DEVELOPMENT.md](./guides/COLLECTOR_DEVELOPMENT.md) | Released |
+| MON-GUID-011 | Exporter Development Guide | [EXPORTER_DEVELOPMENT.md](./guides/EXPORTER_DEVELOPMENT.md) | Released |
+| MON-GUID-012 | Monitoring System - Frequently Asked Questions | [FAQ.md](./guides/FAQ.md) | Released |
+| MON-GUID-013 | vcpkg Port Management | [PORT_MANAGEMENT.md](./guides/PORT_MANAGEMENT.md) | Released |
+| MON-GUID-014 | Monitoring System - 빠른 시작 가이드 | [QUICK_START.kr.md](./guides/QUICK_START.kr.md) | Released |
+| MON-GUID-015 | Monitoring System - Quick Start Guide | [QUICK_START.md](./guides/QUICK_START.md) | Released |
+| MON-GUID-016 | Storage Backend Implementation Guide | [STORAGE_BACKENDS.md](./guides/STORAGE_BACKENDS.md) | Released |
+| MON-GUID-017 | Stream Processing and Aggregation Framework | [STREAM_PROCESSING.md](./guides/STREAM_PROCESSING.md) | Released |
+| MON-GUID-018 | 문제 해결 가이드 | [TROUBLESHOOTING.kr.md](./guides/TROUBLESHOOTING.kr.md) | Released |
+| MON-GUID-019 | Troubleshooting Guide | [TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
+| MON-GUID-020 | Monitoring System 튜토리얼 | [TUTORIAL.kr.md](./guides/TUTORIAL.kr.md) | Released |
+| MON-GUID-021 | Monitoring System Tutorial | [TUTORIAL.md](./guides/TUTORIAL.md) | Released |
+| MON-GUID-022 | vcpkg Overlay Ports Guide | [VCPKG_OVERLAY_PORTS.md](./guides/VCPKG_OVERLAY_PORTS.md) | Released |
+| MON-GUID-023 | Monitoring System Integration Guide | [README.md](./integration/README.md) | Released |
+| MON-GUID-024 | Plugin Development Guide | [plugin_development_guide.md](./plugin_development_guide.md) | Released |
 
-| Document | Description | Korean | Lines |
-|----------|-------------|--------|-------|
-| [01-ARCHITECTURE.md](01-ARCHITECTURE.md) | System architecture, event bus, integration topology | [🇰🇷](01-ARCHITECTURE.kr.md) | 50+ |
-| [02-API_REFERENCE.md](02-API_REFERENCE.md) | Complete API docs: metrics, tracing, alerting, dashboard | [🇰🇷](02-API_REFERENCE.kr.md) | 1000+ |
+### Performance (14)
 
-### 📗 User Guides
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| MON-PERF-001 | Monitoring System - 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| MON-PERF-002 | Monitoring System - Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| MON-PERF-003 | Performance Profiling Guide for monitoring_system | [PROFILING_GUIDE.md](./advanced/PROFILING_GUIDE.md) | Released |
+| MON-PERF-004 | Performance Optimization Cookbook | [PERFORMANCE_COOKBOOK.md](./guides/PERFORMANCE_COOKBOOK.md) | Released |
+| MON-PERF-005 | Monitoring System - 성능 기준 메트릭 | [BASELINE.kr.md](./performance/BASELINE.kr.md) | Released |
+| MON-PERF-006 | Baseline Performance Metrics | [BASELINE.md](./performance/BASELINE.md) | Released |
+| MON-PERF-007 | Performance Baseline Measurements | [PERFORMANCE_BASELINE.md](./performance/PERFORMANCE_BASELINE.md) | Released |
+| MON-PERF-008 | 성능 튜닝 가이드 | [PERFORMANCE_TUNING.kr.md](./performance/PERFORMANCE_TUNING.kr.md) | Released |
+| MON-PERF-009 | Performance Tuning Guide | [PERFORMANCE_TUNING.md](./performance/PERFORMANCE_TUNING.md) | Released |
+| MON-PERF-010 | monitoring_system Sanitizer 기준선 | [SANITIZER_BASELINE.kr.md](./performance/SANITIZER_BASELINE.kr.md) | Released |
+| MON-PERF-011 | monitoring_system Sanitizer Baseline | [SANITIZER_BASELINE.md](./performance/SANITIZER_BASELINE.md) | Released |
+| MON-PERF-012 | Sprint 2 Performance Verification Results | [SPRINT_2_PERFORMANCE_RESULTS.md](./performance/SPRINT_2_PERFORMANCE_RESULTS.md) | Released |
+| MON-PERF-013 | 정적 분석 기준선 - monitoring_system | [STATIC_ANALYSIS_BASELINE.kr.md](./performance/STATIC_ANALYSIS_BASELINE.kr.md) | Released |
+| MON-PERF-014 | Static Analysis Baseline - monitoring_system | [STATIC_ANALYSIS_BASELINE.md](./performance/STATIC_ANALYSIS_BASELINE.md) | Released |
 
-Step-by-step guides for users:
+### Migration (5)
 
-| Document | Description | Korean | Lines |
-|----------|-------------|--------|-------|
-| [QUICK_START.md](guides/QUICK_START.md) | 5-minute getting started guide | - | 708 |
-| [FAQ.md](guides/FAQ.md) | 25 frequently asked questions with examples | - | 991 |
-| [TROUBLESHOOTING.md](guides/TROUBLESHOOTING.md) | Common problems and solutions | [🇰🇷](guides/TROUBLESHOOTING.kr.md) | 600+ |
-| [BEST_PRACTICES.md](guides/BEST_PRACTICES.md) | Production patterns for metrics, alerting, tracing | - | 1190 |
-| [TUTORIAL.md](guides/TUTORIAL.md) | Step-by-step tutorial with examples | [🇰🇷](guides/TUTORIAL.kr.md) | 784 |
-| [SECURITY.md](guides/SECURITY.md) | Security policy and vulnerability reporting | [🇰🇷](guides/SECURITY.kr.md) | 200+ |
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| MON-MIGR-001 | Migration Guide - Monitoring System | [MIGRATION.md](./advanced/MIGRATION.md) | Released |
+| MON-MIGR-002 | 마이그레이션 가이드: 인터페이스 기반 아키텍처 | [MIGRATION_GUIDE_V2.kr.md](./advanced/MIGRATION_GUIDE_V2.kr.md) | Released |
+| MON-MIGR-003 | Migration Guide: Interface-Based Architecture | [MIGRATION_GUIDE_V2.md](./advanced/MIGRATION_GUIDE_V2.md) | Released |
+| MON-MIGR-004 | 네임스페이스 마이그레이션 가이드 | [NAMESPACE_MIGRATION.kr.md](./guides/NAMESPACE_MIGRATION.kr.md) | Released |
+| MON-MIGR-005 | Namespace Migration Guide | [NAMESPACE_MIGRATION.md](./guides/NAMESPACE_MIGRATION.md) | Released |
 
-### 📙 Advanced Topics
+### Integration (4)
 
-For experienced users and contributors:
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| MON-INTR-001 | Distributed Tracing Deep Dive Guide | [DISTRIBUTED_TRACING.md](./guides/DISTRIBUTED_TRACING.md) | Released |
+| MON-INTR-002 | Integration Guide - Monitoring System | [INTEGRATION.md](./guides/INTEGRATION.md) | Released |
+| MON-INTR-003 | OpenTelemetry Collector 사이드카 패턴 | [OTEL_COLLECTOR_SIDECAR.kr.md](./guides/OTEL_COLLECTOR_SIDECAR.kr.md) | Released |
+| MON-INTR-004 | OpenTelemetry Collector Sidecar Pattern | [OTEL_COLLECTOR_SIDECAR.md](./guides/OTEL_COLLECTOR_SIDECAR.md) | Released |
 
-| Document | Description | Korean | Lines |
-|----------|-------------|--------|-------|
-| [ARCHITECTURE_GUIDE.md](advanced/ARCHITECTURE_GUIDE.md) | Detailed system design and patterns | [🇰🇷](advanced/ARCHITECTURE_GUIDE.kr.md) | 800+ |
-| [ARCHITECTURE_ISSUES.md](advanced/ARCHITECTURE_ISSUES.md) | Known architectural issues | [🇰🇷](advanced/ARCHITECTURE_ISSUES.kr.md) | 200+ |
-| [CURRENT_STATE.md](advanced/CURRENT_STATE.md) | Current implementation status | [🇰🇷](advanced/CURRENT_STATE.kr.md) | 150+ |
-| [MIGRATION_GUIDE_V2.md](advanced/MIGRATION_GUIDE_V2.md) | Migration guide to version 2 | [🇰🇷](advanced/MIGRATION_GUIDE_V2.kr.md) | 300+ |
-| [INTERFACE_SEPARATION_STRATEGY.md](advanced/INTERFACE_SEPARATION_STRATEGY.md) | Interface design strategy | - | 200+ |
-| [THREAD_LOCAL_COLLECTOR_DESIGN.md](advanced/THREAD_LOCAL_COLLECTOR_DESIGN.md) | Thread-local collection design | - | 150+ |
-| [PROFILING_GUIDE.md](advanced/PROFILING_GUIDE.md) | Performance profiling guide | - | 200+ |
+### Quality (4)
 
-### 📊 Performance
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| MON-QUAL-001 | Monitoring System - 프로덕션 품질 메트릭 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
+| MON-QUAL-002 | Monitoring System - Production Quality Metrics | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
+| MON-QUAL-003 | Testing Guide | [TESTING_GUIDE.md](./contributing/TESTING_GUIDE.md) | Released |
+| MON-QUAL-004 | Reliability Patterns Usage Guide | [RELIABILITY_PATTERNS.md](./guides/RELIABILITY_PATTERNS.md) | Released |
 
-Performance metrics and optimization:
+### Security (2)
 
-| Document | Description | Korean | Lines |
-|----------|-------------|--------|-------|
-| [BASELINE.md](performance/BASELINE.md) | Performance baseline: 80ns record, 5M ops/s | [🇰🇷](performance/BASELINE.kr.md) | 300+ |
-| [PERFORMANCE_BASELINE.md](performance/PERFORMANCE_BASELINE.md) | Detailed performance metrics | - | 200+ |
-| [PERFORMANCE_TUNING.md](performance/PERFORMANCE_TUNING.md) | Performance tuning strategies | [🇰🇷](performance/PERFORMANCE_TUNING.kr.md) | 400+ |
-| [SANITIZER_BASELINE.md](performance/SANITIZER_BASELINE.md) | Sanitizer results (TSan, ASan, UBSan) | [🇰🇷](performance/SANITIZER_BASELINE.kr.md) | 150+ |
-| [STATIC_ANALYSIS_BASELINE.md](performance/STATIC_ANALYSIS_BASELINE.md) | Static analysis results (Clang-Tidy, Cppcheck) | [🇰🇷](performance/STATIC_ANALYSIS_BASELINE.kr.md) | 100+ |
-| [SPRINT_2_PERFORMANCE_RESULTS.md](performance/SPRINT_2_PERFORMANCE_RESULTS.md) | Sprint 2 performance achievements | - | 100+ |
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| MON-SECU-001 | 보안 정책 | [SECURITY.kr.md](./guides/SECURITY.kr.md) | Released |
+| MON-SECU-002 | Security Policy | [SECURITY.md](./guides/SECURITY.md) | Released |
 
-### 🤝 Contributing
+### Project (7)
 
-For contributors and maintainers:
-
-| Document | Description | Korean | Lines |
-|----------|-------------|--------|-------|
-| [CONTRIBUTING.md](contributing/CONTRIBUTING.md) | Contribution guidelines, code style, testing | [🇰🇷](contributing/CONTRIBUTING.kr.md) | 600+ |
-| [CI_CD_GUIDE.md](contributing/CI_CD_GUIDE.md) | CI/CD pipeline, sanitizers, benchmarks | - | 954 |
-| [TESTING_GUIDE.md](contributing/TESTING_GUIDE.md) | Testing strategy and procedures | - | 400+ |
-
----
-
-## Documentation by Role
-
-### 👤 For New Users
-
-**Getting Started Path**:
-1. **⚡ Quick Start** - [5-minute guide](guides/QUICK_START.md) to first program
-2. **🏗️ Architecture** - [System overview](01-ARCHITECTURE.md)
-3. **📖 API Reference** - [Complete API](02-API_REFERENCE.md) documentation
-4. **💡 Tutorial** - [Step-by-step guide](guides/TUTORIAL.md) with examples
-
-**When You Have Issues**:
-- Check [FAQ](guides/FAQ.md) first (25+ common questions)
-- Use [Troubleshooting](guides/TROUBLESHOOTING.md) for problems
-- Search [GitHub Issues](https://github.com/kcenon/monitoring_system/issues)
-
-### 💻 For Experienced Developers
-
-**Advanced Usage Path**:
-1. **🏗️ Architecture** - Understand [system design](advanced/ARCHITECTURE_GUIDE.md)
-2. **📖 API Reference** - Study [advanced APIs](02-API_REFERENCE.md)
-3. **✨ Best Practices** - Learn [production patterns](guides/BEST_PRACTICES.md)
-4. **📊 Performance** - Review [benchmarks](performance/BASELINE.md)
-
-**Deep Dive Topics**:
-- [Thread-Local Collection](advanced/THREAD_LOCAL_COLLECTOR_DESIGN.md) - Performance optimization
-- [Interface Separation](advanced/INTERFACE_SEPARATION_STRATEGY.md) - Design patterns
-- [Profiling Guide](advanced/PROFILING_GUIDE.md) - Performance analysis
-- [Architecture Issues](advanced/ARCHITECTURE_ISSUES.md) - Known limitations
-
-### 🔧 For DevOps Engineers
-
-**Deployment Path**:
-1. **📚 Quick Start** - [Installation and setup](guides/QUICK_START.md)
-2. **📊 Performance Tuning** - [Optimization strategies](performance/PERFORMANCE_TUNING.md)
-3. **✨ Best Practices** - [Production deployment](guides/BEST_PRACTICES.md#production-deployment)
-4. **🐛 Troubleshooting** - [Common issues](guides/TROUBLESHOOTING.md)
-
-**Monitoring and Tuning**:
-- [Performance Baseline](performance/BASELINE.md) - 80ns record latency, 5M ops/s
-- [Metrics Performance](performance/PERFORMANCE_BASELINE.md) - Backend-specific metrics
-- [CI/CD Pipeline](contributing/CI_CD_GUIDE.md) - Automation
-
-### 🤝 For Contributors
-
-**Contribution Path**:
-1. **🤝 Contributing** - [How to contribute](contributing/CONTRIBUTING.md)
-2. **🚀 CI/CD** - [Pipeline documentation](contributing/CI_CD_GUIDE.md)
-3. **🏗️ Architecture** - [System internals](advanced/ARCHITECTURE_GUIDE.md)
-4. **📊 Current State** - [Implementation status](advanced/CURRENT_STATE.md)
-
-**Development Resources**:
-- [Code Style](contributing/CONTRIBUTING.md#coding-standards)
-- [Testing Guide](contributing/TESTING_GUIDE.md)
-- [Current Status](advanced/CURRENT_STATE.md) - What's implemented
-
----
-
-## By Feature
-
-### 📊 Metrics Collection
-
-| Topic | Document | Section |
-|-------|----------|---------|
-| API | [API Reference](02-API_REFERENCE.md) | Metrics Collection |
-| Best Practices | [Best Practices](guides/BEST_PRACTICES.md) | Metrics Design |
-| Performance | [Baseline](performance/BASELINE.md) | 80ns record latency |
-| Examples | [FAQ](guides/FAQ.md) | Metrics Collection |
-
-### 🔍 Distributed Tracing
-
-| Topic | Document | Section |
-|-------|----------|---------|
-| API | [API Reference](02-API_REFERENCE.md) | Distributed Tracer |
-| Best Practices | [Best Practices](guides/BEST_PRACTICES.md) | Distributed Tracing |
-| Architecture | [Architecture Guide](advanced/ARCHITECTURE_GUIDE.md) | Tracing System |
-| Examples | [Quick Start](guides/QUICK_START.md) | Tracing |
-
-### 🚨 Alerting System
-
-| Topic | Document | Section |
-|-------|----------|---------|
-| API | [API Reference](02-API_REFERENCE.md) | Alerting Engine |
-| Best Practices | [Best Practices](guides/BEST_PRACTICES.md) | Alert Design |
-| FAQ | [FAQ](guides/FAQ.md) | Alerting |
-| Examples | [Quick Start](guides/QUICK_START.md) | Alerting |
-
-### 📈 Web Dashboard
-
-| Topic | Document | Section |
-|-------|----------|---------|
-| Setup | [Quick Start](guides/QUICK_START.md) | Web Dashboard |
-| API | [API Reference](02-API_REFERENCE.md) | Dashboard API |
-| Security | [Security](guides/SECURITY.md) | Dashboard Access |
-| Troubleshooting | [Troubleshooting](guides/TROUBLESHOOTING.md) | Dashboard Issues |
-
-### 🗄️ Storage
-
-| Topic | Document | Section |
-|-------|----------|---------|
-| Configuration | [Best Practices](guides/BEST_PRACTICES.md) | Storage Configuration |
-| Performance | [Performance Tuning](performance/PERFORMANCE_TUNING.md) | Storage Optimization |
-| FAQ | [FAQ](guides/FAQ.md) | Storage |
-| Architecture | [Architecture Guide](advanced/ARCHITECTURE_GUIDE.md) | Storage Backend |
-
-### 🔗 Integration
-
-| Topic | Document | Section |
-|-------|----------|---------|
-| thread_system | [FAQ](guides/FAQ.md) | Thread System Integration |
-| logger_system | [FAQ](guides/FAQ.md) | Logger System Integration |
-| Prometheus | [FAQ](guides/FAQ.md) | Export to Prometheus |
-| OpenTelemetry | [FAQ](guides/FAQ.md) | OpenTelemetry Integration |
-
----
-
-## Project Information
-
-### Current Status
-- **Version**: 0.3.0.0 (Phase 3 with Alerting & Dashboard)
-- **C++ Standard**: C++20
-- **License**: BSD 3-Clause
-- **Test Status**: Under Development
-
-### Supported Features
-- ✅ **Metrics Collection** - Counter, Gauge, Histogram, Summary
-- ✅ **Distributed Tracing** - Full trace correlation and analysis
-- ✅ **Real-time Alerting** - Rule-based alert engine
-- ✅ **Multi-channel Notifications** - Email, Slack, PagerDuty, Webhook
-- ✅ **Web Dashboard** - Interactive visualization
-- ✅ **Storage Backends** - In-memory, File-based, Custom
-- ✅ **Exporters** - Prometheus, OpenTelemetry, Jaeger
-
-### Key Features
-- 📊 **High Performance** - 80ns record latency, 5M ops/s throughput
-- 🎯 **Low Overhead** - <1% CPU, minimal memory footprint
-- 🔗 **Unified Observability** - Metrics, traces, and alerts in one system
-- 🚨 **Smart Alerting** - Multi-level severity, grouping, inhibition
-- 📈 **Real-time Dashboard** - Interactive web UI with live updates
-- 🔧 **Flexible Storage** - Multiple backends with retention policies
-- 🧵 **Thread Safe** - Concurrent operations verified with TSan
-- 🔐 **Production Ready** - Security, authentication, RBAC
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| MON-PROJ-001 | 변경 로그 | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| MON-PROJ-002 | Changelog | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| MON-PROJ-003 | Monitoring System - 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| MON-PROJ-004 | Monitoring System - Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| MON-PROJ-005 | SOUP List &mdash; monitoring_system | [SOUP.md](./SOUP.md) | Released |
+| MON-PROJ-006 | Monitoring System에 기여하기 | [CONTRIBUTING.kr.md](./contributing/CONTRIBUTING.kr.md) | Released |
+| MON-PROJ-007 | Contributing to Monitoring System | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
 
 ---
 
-## Contributing to Documentation
-
-### Documentation Standards
-Follow the [Documentation Standard](/Users/raphaelshin/Sources/template_document/DOCUMENTATION_STANDARD.md):
-- Front matter on all documents
-- Code examples must compile
-- Bilingual support (English/Korean)
-- Cross-references with relative links
-
-### Areas for Improvement
-- [ ] Video tutorials for alerting and dashboard
-- [ ] Interactive examples for metric design
-- [ ] More integration scenarios
-- [ ] Performance optimization cookbook
-
-### Submission Process
-1. Read [Contributing Guide](contributing/CONTRIBUTING.md)
-2. Edit markdown files
-3. Test all code examples
-4. Update Korean translations
-5. Submit pull request
-
----
-
-## 📞 Getting Help
-
-### Documentation Issues
-- **Missing info**: [Open documentation issue](https://github.com/kcenon/monitoring_system/issues/new?labels=documentation)
-- **Incorrect examples**: Report with details
-- **Unclear instructions**: Suggest improvements
-
-### Technical Support
-1. Check [FAQ](guides/FAQ.md) - 25+ common questions
-2. Read [Troubleshooting](guides/TROUBLESHOOTING.md) - Solutions to common problems
-3. Search [GitHub Issues](https://github.com/kcenon/monitoring_system/issues)
-4. Ask on [GitHub Discussions](https://github.com/kcenon/monitoring_system/discussions)
-
-### Support Resources
-- **Issues**: Bug reports and feature requests
-- **Discussions**: Questions and support
-- **Pull Requests**: Code and documentation contributions
-
----
-
-## External Resources
-
-- **GitHub Repository**: [kcenon/monitoring_system](https://github.com/kcenon/monitoring_system)
-- **Issue Tracker**: [GitHub Issues](https://github.com/kcenon/monitoring_system/issues)
-- **Main README**: [../README.md](../README.md)
-- **Changelog**: [CHANGELOG.md.bak](CHANGELOG.md.bak)
-
----
-
-## Documentation Roadmap
-
-### ✅ Current (v1.0 - 2025-11-11)
-- ✅ Complete API reference with examples
-- ✅ Comprehensive FAQ (25+ questions)
-- ✅ Detailed troubleshooting guide
-- ✅ Best practices documentation
-- ✅ Performance benchmarks
-- ✅ CI/CD documentation
-- ✅ Quick start guide
-- ✅ Tutorial with examples
-
-### 📋 Future Enhancements
-- 🎥 Video tutorials for alerting and dashboard
-- 📊 Interactive performance dashboard
-- 🌐 Multi-language support (Japanese, Chinese)
-- 📖 Migration guides for major versions
-- 🔄 Integration guides for more systems
-
----
-
-**Monitoring System Documentation** - Modern Observability for C++20
-
-**Last Updated**: 2025-11-11
-**Next Review**: 2026-02-11
+*Registry generated for issue [#563](https://github.com/kcenon/monitoring_system/issues/563).*

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # SOUP List &mdash; monitoring_system
 
+> **SSOT**: This document is the single source of truth for **SOUP List &mdash; monitoring_system**.
+
 > **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**
 >
 > This document is the authoritative reference for all external software dependencies.

--- a/docs/advanced/ARCHITECTURE.md
+++ b/docs/advanced/ARCHITECTURE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Architecture Overview
 
+> **SSOT**: This document is the single source of truth for **Architecture Overview**.
+
 ## Purpose
 
 The monitoring_system provides comprehensive metrics collection, storage, analysis, health checks, and event-driven observability for C++20 services. It is designed with an interface-first approach and can operate standalone or integrate seamlessly with the thread_system and logger_system ecosystem.

--- a/docs/advanced/ARCHITECTURE_GUIDE.kr.md
+++ b/docs/advanced/ARCHITECTURE_GUIDE.kr.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Monitoring System 아키텍처 가이드
 
+> **SSOT**: This document is the single source of truth for **Monitoring System 아키텍처 가이드**.
+
 > **Language:** [English](ARCHITECTURE_GUIDE.md) | **한국어**
 
 **Phase 4 - 현재 구현 아키텍처**

--- a/docs/advanced/ARCHITECTURE_GUIDE.md
+++ b/docs/advanced/ARCHITECTURE_GUIDE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Monitoring System Architecture Guide
 
+> **SSOT**: This document is the single source of truth for **Monitoring System Architecture Guide**.
+
 > **Language:** **English** | [한국어](ARCHITECTURE_GUIDE.kr.md)
 
 **Phase 4 - Current Implementation Architecture**

--- a/docs/advanced/ARCHITECTURE_ISSUES.kr.md
+++ b/docs/advanced/ARCHITECTURE_ISSUES.kr.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Architecture Issues - Phase 0 식별
 
+> **SSOT**: This document is the single source of truth for **Architecture Issues - Phase 0 식별**.
+
 > **Language:** [English](ARCHITECTURE_ISSUES.md) | **한국어**
 
 ## 목차

--- a/docs/advanced/ARCHITECTURE_ISSUES.md
+++ b/docs/advanced/ARCHITECTURE_ISSUES.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Architecture Issues - Phase 0 Identification
 
+> **SSOT**: This document is the single source of truth for **Architecture Issues - Phase 0 Identification**.
+
 > **Language:** **English** | [한국어](ARCHITECTURE_ISSUES.kr.md)
 
 ## Table of Contents

--- a/docs/advanced/CURRENT_STATE.kr.md
+++ b/docs/advanced/CURRENT_STATE.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 시스템 현재 상태 - Phase 0 기준선
 
+> **SSOT**: This document is the single source of truth for **시스템 현재 상태 - Phase 0 기준선**.
+
 > **Language:** [English](CURRENT_STATE.md) | **한국어**
 
 **문서 버전**: 0.1.0

--- a/docs/advanced/CURRENT_STATE.md
+++ b/docs/advanced/CURRENT_STATE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # System Current State - Phase 0 Baseline
 
+> **SSOT**: This document is the single source of truth for **System Current State - Phase 0 Baseline**.
+
 > **Language:** **English** | [한국어](CURRENT_STATE.kr.md)
 
 **Document Version**: 1.0

--- a/docs/advanced/INTERFACE_SEPARATION_STRATEGY.md
+++ b/docs/advanced/INTERFACE_SEPARATION_STRATEGY.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Interface Separation Strategy
 
+> **SSOT**: This document is the single source of truth for **Interface Separation Strategy**.
+
 **Version**: 0.1.0.0
 **Last Updated**: 2025-11-08
 **Status**: Planning Document

--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Migration Guide - Monitoring System
 
+> **SSOT**: This document is the single source of truth for **Migration Guide - Monitoring System**.
+
 > **Language:** **English** | [한국어](MIGRATION.kr.md)
 
 ## Overview

--- a/docs/advanced/MIGRATION_GUIDE_V2.kr.md
+++ b/docs/advanced/MIGRATION_GUIDE_V2.kr.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # 마이그레이션 가이드: 인터페이스 기반 아키텍처
 
+> **SSOT**: This document is the single source of truth for **마이그레이션 가이드: 인터페이스 기반 아키텍처**.
+
 > **Language:** [English](MIGRATION_GUIDE_V2.md) | **한국어**
 
 **대상 독자**: logger_system 및/또는 monitoring_system을 사용하는 개발자

--- a/docs/advanced/MIGRATION_GUIDE_V2.md
+++ b/docs/advanced/MIGRATION_GUIDE_V2.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Migration Guide: Interface-Based Architecture
 
+> **SSOT**: This document is the single source of truth for **Migration Guide: Interface-Based Architecture**.
+
 > **Language:** **English** | [한국어](MIGRATION_GUIDE_V2.kr.md)
 
 **Target Audience**: Developers using logger_system and/or monitoring_system

--- a/docs/advanced/PROFILING_GUIDE.md
+++ b/docs/advanced/PROFILING_GUIDE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Performance Profiling Guide for monitoring_system
 
+> **SSOT**: This document is the single source of truth for **Performance Profiling Guide for monitoring_system**.
+
 **Date**: 2025-11-09
 **Sprint**: Sprint 2 - Hot Path Optimization
 

--- a/docs/advanced/STRUCTURE.kr.md
+++ b/docs/advanced/STRUCTURE.kr.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Monitoring System - 프로젝트 구조
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - 프로젝트 구조**.
+
 > **언어 선택 (Language)**: [English](STRUCTURE.md) | **한국어**
 
 ## 📁 디렉토리 레이아웃

--- a/docs/advanced/STRUCTURE.md
+++ b/docs/advanced/STRUCTURE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Monitoring System - Project Structure
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - Project Structure**.
+
 > **Language**: **English** | [한국어](STRUCTURE.kr.md)
 
 ## 📁 Directory Layout

--- a/docs/advanced/THREAD_LOCAL_COLLECTOR_DESIGN.md
+++ b/docs/advanced/THREAD_LOCAL_COLLECTOR_DESIGN.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Thread-Local Collector Design
 
+> **SSOT**: This document is the single source of truth for **Thread-Local Collector Design**.
+
 **Date**: 2025-11-09
 **Sprint**: 3-4 (Lock-Free Path)
 **Status**: Design Phase

--- a/docs/contributing/CI_CD_GUIDE.md
+++ b/docs/contributing/CI_CD_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # CI/CD Guide for Monitoring System
 
+> **SSOT**: This document is the single source of truth for **CI/CD Guide for Monitoring System**.
+
 > **Version:** 0.1.0
 > **Last Updated:** 2025-11-11
 > **Audience:** Contributors, Maintainers

--- a/docs/contributing/CONTRIBUTING.kr.md
+++ b/docs/contributing/CONTRIBUTING.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Monitoring System에 기여하기
 
+> **SSOT**: This document is the single source of truth for **Monitoring System에 기여하기**.
+
 > **Language:** [English](CONTRIBUTING.md) | **한국어**
 
 Monitoring System에 대한 기여를 환영합니다! 이 문서는 프로젝트에 기여하기 위한 가이드라인을 제공합니다.

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Contributing to Monitoring System
 
+> **SSOT**: This document is the single source of truth for **Contributing to Monitoring System**.
+
 > **Language:** **English** | [한국어](CONTRIBUTING.kr.md)
 
 We welcome contributions to the Monitoring System! This document provides guidelines for contributing to the project.

--- a/docs/guides/ADVANCED_ALERTS.md
+++ b/docs/guides/ADVANCED_ALERTS.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Advanced Alert Configuration Guide
 
+> **SSOT**: This document is the single source of truth for **Advanced Alert Configuration Guide**.
+
 > **Version**: 0.1.0
 > **Module**: `kcenon::monitoring::alert`
 > **Audience**: Developers integrating the alerting framework into monitoring pipelines

--- a/docs/guides/ALERT_PIPELINE.md
+++ b/docs/guides/ALERT_PIPELINE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Alert Pipeline Guide
 
+> **SSOT**: This document is the single source of truth for **Alert Pipeline Guide**.
+
 This guide covers the alert pipeline feature, enabling automated alerting based on metric thresholds, patterns, and anomalies.
 
 ## Overview

--- a/docs/guides/BEST_PRACTICES.md
+++ b/docs/guides/BEST_PRACTICES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Monitoring System - Best Practices Guide
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - Best Practices Guide**.
+
 > **Version:** 0.1.0
 > **Last Updated:** 2025-11-11
 > **Audience:** Developers, DevOps Engineers, SREs

--- a/docs/guides/COLLECTOR_DEVELOPMENT.md
+++ b/docs/guides/COLLECTOR_DEVELOPMENT.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Collector Development Guide
 
+> **SSOT**: This document is the single source of truth for **Collector Development Guide**.
+
 > **Language:** **English** | [한국어](COLLECTOR_DEVELOPMENT.kr.md)
 
 **Version**: 0.4.0.0

--- a/docs/guides/DISTRIBUTED_TRACING.md
+++ b/docs/guides/DISTRIBUTED_TRACING.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # Distributed Tracing Deep Dive Guide
 
+> **SSOT**: This document is the single source of truth for **Distributed Tracing Deep Dive Guide**.
+
 > **Version**: 0.1.0
 > **Module**: `kcenon::monitoring::tracing`, `kcenon::monitoring::exporters`
 > **Audience**: Developers implementing distributed tracing across services

--- a/docs/guides/DI_AND_CONCEPTS.md
+++ b/docs/guides/DI_AND_CONCEPTS.md
@@ -10,6 +10,8 @@ category: "API"
 
 # DI Container and C++20 Concepts Guide
 
+> **SSOT**: This document is the single source of truth for **DI Container and C++20 Concepts Guide**.
+
 > **Language:** **English** | Advanced Guide
 >
 > **Source Reference**: This guide documents actual implementations from the monitoring_system codebase.

--- a/docs/guides/EXPORTER_DEVELOPMENT.md
+++ b/docs/guides/EXPORTER_DEVELOPMENT.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Exporter Development Guide
 
+> **SSOT**: This document is the single source of truth for **Exporter Development Guide**.
+
 > **Version**: 1.0.0
 > **Last Updated**: 2026-02-09
 > **Parent Epic**: [Documentation Gap Analysis](https://github.com/kcenon/common_system/issues/325)

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Monitoring System - Frequently Asked Questions
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - Frequently Asked Questions**.
+
 > **Version:** 0.1.0
 > **Last Updated:** 2025-11-11
 > **Audience:** Users, Developers, DevOps Engineers

--- a/docs/guides/INTEGRATION.md
+++ b/docs/guides/INTEGRATION.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # Integration Guide - Monitoring System
 
+> **SSOT**: This document is the single source of truth for **Integration Guide - Monitoring System**.
+
 > **Language:** **English** | [한국어](INTEGRATION.kr.md)
 
 ## Overview

--- a/docs/guides/NAMESPACE_MIGRATION.kr.md
+++ b/docs/guides/NAMESPACE_MIGRATION.kr.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # 네임스페이스 마이그레이션 가이드
 
+> **SSOT**: This document is the single source of truth for **네임스페이스 마이그레이션 가이드**.
+
 > **버전:** 1.0.0
 > **최종 업데이트:** 2025-02-05
 > **상태:** 마이그레이션 완료 (v1.0)

--- a/docs/guides/NAMESPACE_MIGRATION.md
+++ b/docs/guides/NAMESPACE_MIGRATION.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Namespace Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Namespace Migration Guide**.
+
 > **Version:** 1.0.0
 > **Last Updated:** 2025-02-05
 > **Status:** Migration Completed (v1.0)

--- a/docs/guides/OTEL_COLLECTOR_SIDECAR.kr.md
+++ b/docs/guides/OTEL_COLLECTOR_SIDECAR.kr.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # OpenTelemetry Collector 사이드카 패턴
 
+> **SSOT**: This document is the single source of truth for **OpenTelemetry Collector 사이드카 패턴**.
+
 > **Language:** [English](OTEL_COLLECTOR_SIDECAR.md) | **한국어**
 
 ## 개요

--- a/docs/guides/OTEL_COLLECTOR_SIDECAR.md
+++ b/docs/guides/OTEL_COLLECTOR_SIDECAR.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # OpenTelemetry Collector Sidecar Pattern
 
+> **SSOT**: This document is the single source of truth for **OpenTelemetry Collector Sidecar Pattern**.
+
 > **Language:** **English** | [한국어](OTEL_COLLECTOR_SIDECAR.kr.md)
 
 ## Overview

--- a/docs/guides/PERFORMANCE_COOKBOOK.md
+++ b/docs/guides/PERFORMANCE_COOKBOOK.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Performance Optimization Cookbook
 
+> **SSOT**: This document is the single source of truth for **Performance Optimization Cookbook**.
+
 > **Language:** **English** | Advanced Guide
 >
 > **Source Reference**: This guide documents actual implementations from the monitoring_system codebase.

--- a/docs/guides/PORT_MANAGEMENT.md
+++ b/docs/guides/PORT_MANAGEMENT.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # vcpkg Port Management
 
+> **SSOT**: This document is the single source of truth for **vcpkg Port Management**.
+
 This document defines the authoritative port management strategy for the kcenon
 ecosystem and serves as the definitive reference for all port-related work.
 

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Monitoring System - 빠른 시작 가이드
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - 빠른 시작 가이드**.
+
 > **Language:** [English](QUICK_START.md) | **한국어**
 
 > **버전:** 0.1.0

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Monitoring System - Quick Start Guide
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - Quick Start Guide**.
+
 > **Version:** 0.1.0
 > **Last Updated:** 2025-11-11
 > **Time to Complete:** 5 minutes

--- a/docs/guides/RELIABILITY_PATTERNS.md
+++ b/docs/guides/RELIABILITY_PATTERNS.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Reliability Patterns Usage Guide
 
+> **SSOT**: This document is the single source of truth for **Reliability Patterns Usage Guide**.
+
 > **Version**: 1.0.0
 > **Last Updated**: 2026-02-09
 > **Parent Epic**: [Documentation Gap Analysis](https://github.com/kcenon/common_system/issues/325)

--- a/docs/guides/SECURITY.kr.md
+++ b/docs/guides/SECURITY.kr.md
@@ -10,6 +10,8 @@ category: "SECU"
 
 # 보안 정책
 
+> **SSOT**: This document is the single source of truth for **보안 정책**.
+
 > **Language:** [English](SECURITY.md) | **한국어**
 
 ## 목차

--- a/docs/guides/SECURITY.md
+++ b/docs/guides/SECURITY.md
@@ -10,6 +10,8 @@ category: "SECU"
 
 # Security Policy
 
+> **SSOT**: This document is the single source of truth for **Security Policy**.
+
 > **Language:** **English** | [한국어](SECURITY.kr.md)
 
 ## Table of Contents

--- a/docs/guides/STORAGE_BACKENDS.md
+++ b/docs/guides/STORAGE_BACKENDS.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Storage Backend Implementation Guide
 
+> **SSOT**: This document is the single source of truth for **Storage Backend Implementation Guide**.
+
 > **Version**: 1.0.0
 > **Last Updated**: 2026-02-09
 > **Parent Epic**: [Documentation Gap Analysis](https://github.com/kcenon/common_system/issues/325)

--- a/docs/guides/STREAM_PROCESSING.md
+++ b/docs/guides/STREAM_PROCESSING.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Stream Processing and Aggregation Framework
 
+> **SSOT**: This document is the single source of truth for **Stream Processing and Aggregation Framework**.
+
 > **Version**: 0.1.0
 > **Status**: Active
 > **Last Updated**: 2025-12-01

--- a/docs/guides/TROUBLESHOOTING.kr.md
+++ b/docs/guides/TROUBLESHOOTING.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 문제 해결 가이드
 
+> **SSOT**: This document is the single source of truth for **문제 해결 가이드**.
+
 > **Language:** [English](TROUBLESHOOTING.md) | **한국어**
 
 ## 목차

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Troubleshooting Guide
 
+> **SSOT**: This document is the single source of truth for **Troubleshooting Guide**.
+
 > **Language:** **English** | [한국어](TROUBLESHOOTING.kr.md)
 
 ## Table of Contents

--- a/docs/guides/TUTORIAL.kr.md
+++ b/docs/guides/TUTORIAL.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Monitoring System 튜토리얼
 
+> **SSOT**: This document is the single source of truth for **Monitoring System 튜토리얼**.
+
 > **Language:** [English](TUTORIAL.md) | **한국어**
 
 ## 소개

--- a/docs/guides/TUTORIAL.md
+++ b/docs/guides/TUTORIAL.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Monitoring System Tutorial
 
+> **SSOT**: This document is the single source of truth for **Monitoring System Tutorial**.
+
 > **Language:** **English** | [한국어](TUTORIAL.kr.md)
 
 ## Introduction

--- a/docs/guides/VCPKG_OVERLAY_PORTS.md
+++ b/docs/guides/VCPKG_OVERLAY_PORTS.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # vcpkg Overlay Ports Guide
 
+> **SSOT**: This document is the single source of truth for **vcpkg Overlay Ports Guide**.
+
 This guide explains how to use the vcpkg overlay ports provided by the
 `monitoring_system` repository, which acts as the **canonical port registry**
 for the entire kcenon ecosystem.

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Monitoring System Integration Guide
 
+> **SSOT**: This document is the single source of truth for **Monitoring System Integration Guide**.
+
 ## Overview
 
 This directory contains integration guides for using monitoring_system with other KCENON systems.

--- a/docs/performance/BASELINE.kr.md
+++ b/docs/performance/BASELINE.kr.md
@@ -11,6 +11,8 @@ category: "PERF"
 <<<<<<< HEAD
 # Monitoring System - 성능 기준 메트릭
 
+> **SSOT**: This document is the single source of truth for **Monitoring System - 성능 기준 메트릭**.
+
 > **언어 선택 (Language)**: [English](BASELINE.md) | **한국어**
 
 **Version**: 0.1.0.0

--- a/docs/performance/BASELINE.md
+++ b/docs/performance/BASELINE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Baseline Performance Metrics
 
+> **SSOT**: This document is the single source of truth for **Baseline Performance Metrics**.
+
 **Document Version**: 3.0
 **Created**: 2025-10-07
 **Updated**: 2026-02-12

--- a/docs/performance/PERFORMANCE_BASELINE.md
+++ b/docs/performance/PERFORMANCE_BASELINE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Performance Baseline Measurements
 
+> **SSOT**: This document is the single source of truth for **Performance Baseline Measurements**.
+
 **Date**: 2025-11-08
 **System**: macOS (8-core, L1D: 64 KiB, L1I: 128 KiB, L2: 4096 KiB)
 **Compiler**: Default system compiler

--- a/docs/performance/PERFORMANCE_TUNING.kr.md
+++ b/docs/performance/PERFORMANCE_TUNING.kr.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # 성능 튜닝 가이드
 
+> **SSOT**: This document is the single source of truth for **성능 튜닝 가이드**.
+
 > **Language:** [English](PERFORMANCE_TUNING.md) | **한국어**
 
 ## 목차

--- a/docs/performance/PERFORMANCE_TUNING.md
+++ b/docs/performance/PERFORMANCE_TUNING.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Performance Tuning Guide
 
+> **SSOT**: This document is the single source of truth for **Performance Tuning Guide**.
+
 > **Language:** **English** | [한국어](PERFORMANCE_TUNING.kr.md)
 
 ## Table of Contents

--- a/docs/performance/SANITIZER_BASELINE.kr.md
+++ b/docs/performance/SANITIZER_BASELINE.kr.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # monitoring_system Sanitizer 기준선
 
+> **SSOT**: This document is the single source of truth for **monitoring_system Sanitizer 기준선**.
+
 > **Language:** [English](SANITIZER_BASELINE.md) | **한국어**
 
 **단계**: 0 - 기반 및 도구

--- a/docs/performance/SANITIZER_BASELINE.md
+++ b/docs/performance/SANITIZER_BASELINE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # monitoring_system Sanitizer Baseline
 
+> **SSOT**: This document is the single source of truth for **monitoring_system Sanitizer Baseline**.
+
 > **Language:** **English** | [한국어](SANITIZER_BASELINE.kr.md)
 
 **Phase**: 0 - Foundation and Tooling

--- a/docs/performance/SPRINT_2_PERFORMANCE_RESULTS.md
+++ b/docs/performance/SPRINT_2_PERFORMANCE_RESULTS.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Sprint 2 Performance Verification Results
 
+> **SSOT**: This document is the single source of truth for **Sprint 2 Performance Verification Results**.
+
 **Date**: 2025-11-09
 **Branch**: feature/sprint-2-hot-path-optimization
 **Commits**: 4936d24 (Multiple inheritance removal), aa0c185 (LRU eviction)

--- a/docs/performance/STATIC_ANALYSIS_BASELINE.kr.md
+++ b/docs/performance/STATIC_ANALYSIS_BASELINE.kr.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # 정적 분석 기준선 - monitoring_system
 
+> **SSOT**: This document is the single source of truth for **정적 분석 기준선 - monitoring_system**.
+
 > **Language:** [English](STATIC_ANALYSIS_BASELINE.md) | **한국어**
 
 **날짜**: 2025-10-03

--- a/docs/performance/STATIC_ANALYSIS_BASELINE.md
+++ b/docs/performance/STATIC_ANALYSIS_BASELINE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Static Analysis Baseline - monitoring_system
 
+> **SSOT**: This document is the single source of truth for **Static Analysis Baseline - monitoring_system**.
+
 > **Language:** **English** | [한국어](STATIC_ANALYSIS_BASELINE.kr.md)
 
 **Date**: 2025-10-03

--- a/docs/plugin_api_reference.md
+++ b/docs/plugin_api_reference.md
@@ -10,6 +10,8 @@ category: "API"
 
 # Plugin API Reference
 
+> **SSOT**: This document is the single source of truth for **Plugin API Reference**.
+
 Complete reference for the collector plugin API.
 
 ## Table of Contents

--- a/docs/plugin_architecture.md
+++ b/docs/plugin_architecture.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Collector Plugin Architecture
 
+> **SSOT**: This document is the single source of truth for **Collector Plugin Architecture**.
+
 ## Overview
 
 The collector plugin architecture provides a unified interface for all metric collectors in the monitoring system. It enables:

--- a/docs/plugin_development_guide.md
+++ b/docs/plugin_development_guide.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Plugin Development Guide
 
+> **SSOT**: This document is the single source of truth for **Plugin Development Guide**.
+
 ## Table of Contents
 
 - [Quick Start](#quick-start)


### PR DESCRIPTION
## Summary

- Create `docs/README.md` as the single source of truth documentation index for monitoring_system
- Add SSOT declarations (`> **SSOT**: ...`) to each authoritative document header
- Registry table lists all 74 documents with doc_id, topic, authority document link, and status
- Documents grouped by category (Architecture, API, Features, Guides, etc.)
- Verified no duplicate doc_id values and all file links are valid

## Test Plan

- [x] All 74 document entries have valid file links
- [x] No duplicate doc_id values within the project
- [x] SSOT declarations added to authoritative documents
- [x] Registry follows the format specified in kcenon/common_system#563

Closes kcenon/common_system#563