### PR TITLE
docs: add @file Doxygen blocks to public API headers

### DIFF
--- a/include/kcenon/monitoring/adapters/common_to_monitoring_adapter.h
+++ b/include/kcenon/monitoring/adapters/common_to_monitoring_adapter.h
@@ -1,3 +1,10 @@
+/**
+ * @file common_to_monitoring_adapter.h
+ * @brief Adapter exposing monitoring_system as common::interfaces::IMonitor.
+ *
+ * @see monitoring_to_common_adapter.h
+ */
+
 #pragma once
 
 // BSD 3-Clause License

--- a/include/kcenon/monitoring/adapters/logger_to_monitoring_adapter.h
+++ b/include/kcenon/monitoring/adapters/logger_to_monitoring_adapter.h
@@ -1,3 +1,9 @@
+/**
+ * @file logger_to_monitoring_adapter.h
+ * @brief Logger system adapter using dependency injection for monitoring integration.
+ *
+ */
+
 #pragma once
 
 #ifndef KCENON_MONITORING_ADAPTERS_LOGGER_TO_MONITORING_ADAPTER_H

--- a/include/kcenon/monitoring/adapters/monitor_adapter.h
+++ b/include/kcenon/monitoring/adapters/monitor_adapter.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file monitor_adapter.h
+ * @brief Standalone adapter for performance_monitor without DI.
+ *
+ */
+
 #pragma once
 
 #include <kcenon/monitoring/core/performance_monitor.h>

--- a/include/kcenon/monitoring/adapters/monitoring_to_common_adapter.h
+++ b/include/kcenon/monitoring/adapters/monitoring_to_common_adapter.h
@@ -1,3 +1,10 @@
+/**
+ * @file monitoring_to_common_adapter.h
+ * @brief Health status conversion between monitoring_system and common_system.
+ *
+ * @see common_to_monitoring_adapter.h
+ */
+
 #pragma once
 
 // BSD 3-Clause License

--- a/include/kcenon/monitoring/adapters/thread_to_monitoring_adapter.h
+++ b/include/kcenon/monitoring/adapters/thread_to_monitoring_adapter.h
@@ -1,3 +1,10 @@
+/**
+ * @file thread_to_monitoring_adapter.h
+ * @brief Thread system adapter for pulling metrics from thread_system.
+ *
+ * @see thread_system_collector.h
+ */
+
 #pragma once
 
 // Define guard so compatibility shim does not try to include a non‑existent path

--- a/include/kcenon/monitoring/collectors/logger_system_collector.h
+++ b/include/kcenon/monitoring/collectors/logger_system_collector.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file logger_system_collector.h
+ * @brief Metric collector for logger_system log statistics.
+ *
+ * @see collector_plugin
+ */
+
 #pragma once
 
 #include <algorithm>

--- a/include/kcenon/monitoring/collectors/plugin_metric_collector.h
+++ b/include/kcenon/monitoring/collectors/plugin_metric_collector.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file plugin_metric_collector.h
+ * @brief Plugin-based metric collector with dynamic discovery and registration.
+ *
+ * @see metric_collector_interface
+ */
+
 #pragma once
 
 #include <algorithm>

--- a/include/kcenon/monitoring/collectors/system_resource_collector.h
+++ b/include/kcenon/monitoring/collectors/system_resource_collector.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file system_resource_collector.h
+ * @brief System resource collector for CPU, memory, and disk metrics.
+ *
+ * @see metrics_provider For platform-specific implementations
+ */
+
 #pragma once
 
 #include <array>

--- a/include/kcenon/monitoring/collectors/thread_system_collector.h
+++ b/include/kcenon/monitoring/collectors/thread_system_collector.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file thread_system_collector.h
+ * @brief Metric collector for thread_system pool and queue statistics.
+ *
+ * @see thread_to_monitoring_adapter.h
+ */
+
 #pragma once
 
 #include <algorithm>

--- a/include/kcenon/monitoring/core/central_collector.h
+++ b/include/kcenon/monitoring/core/central_collector.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file central_collector.h
+ * @brief Central collector for aggregating metrics from thread-local buffers.
+ *
+ * @see interface_metric_source
+ */
+
 #pragma once
 
 #include <kcenon/monitoring/core/thread_local_buffer.h>

--- a/include/kcenon/monitoring/core/performance_types.h
+++ b/include/kcenon/monitoring/core/performance_types.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file performance_types.h
+ * @brief Lightweight performance profile types for aggregated metrics.
+ *
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/include/kcenon/monitoring/core/safe_event_dispatcher.h
+++ b/include/kcenon/monitoring/core/safe_event_dispatcher.h
@@ -3,6 +3,13 @@
 // See the LICENSE file in the project root for full license information.
 
 
+/**
+ * @file safe_event_dispatcher.h
+ * @brief Thread-safe event dispatcher with error boundary for handler failures.
+ *
+ * @see event_bus.h
+ */
+
 #pragma once
 
 #include "event_bus.h"

--- a/include/kcenon/monitoring/optimization/lockfree_queue.h
+++ b/include/kcenon/monitoring/optimization/lockfree_queue.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file lockfree_queue.h
+ * @brief Lock-free MPMC queue optimized for metric collection pipelines.
+ *
+ */
+
 #pragma once
 
 #include <atomic>

--- a/include/kcenon/monitoring/optimization/memory_pool.h
+++ b/include/kcenon/monitoring/optimization/memory_pool.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file memory_pool.h
+ * @brief Platform-specific aligned memory allocation pool for monitoring objects.
+ *
+ */
+
 #pragma once
 
 #include <atomic>

--- a/include/kcenon/monitoring/optimization/simd_aggregator.h
+++ b/include/kcenon/monitoring/optimization/simd_aggregator.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file simd_aggregator.h
+ * @brief SIMD-accelerated metric aggregation (AVX2/NEON auto-detected).
+ *
+ */
+
 #pragma once
 
 #include <algorithm>

--- a/include/kcenon/monitoring/reliability/data_consistency.h
+++ b/include/kcenon/monitoring/reliability/data_consistency.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file data_consistency.h
+ * @brief Transaction states and consistency validation for metric storage.
+ *
+ */
+
 #pragma once
 
 #include <atomic>

--- a/include/kcenon/monitoring/reliability/error_boundary.h
+++ b/include/kcenon/monitoring/reliability/error_boundary.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file error_boundary.h
+ * @brief Error boundary with degradation levels for fault isolation.
+ *
+ * @see fault_tolerance_manager.h
+ */
+
 #pragma once
 
 #include <atomic>

--- a/include/kcenon/monitoring/reliability/fault_tolerance_manager.h
+++ b/include/kcenon/monitoring/reliability/fault_tolerance_manager.h
@@ -2,6 +2,14 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file fault_tolerance_manager.h
+ * @brief Fault tolerance manager coordinating circuit breakers and retries.
+ *
+ * @see error_boundary.h
+ * @see retry_policy.h
+ */
+
 #pragma once
 
 #include "circuit_breaker.h"

--- a/include/kcenon/monitoring/reliability/graceful_degradation.h
+++ b/include/kcenon/monitoring/reliability/graceful_degradation.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file graceful_degradation.h
+ * @brief Service priority levels and graceful degradation strategies.
+ *
+ */
+
 #pragma once
 
 #include "error_boundary.h"

--- a/include/kcenon/monitoring/reliability/resource_manager.h
+++ b/include/kcenon/monitoring/reliability/resource_manager.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file resource_manager.h
+ * @brief Resource exhaustion handling strategies and limits.
+ *
+ */
+
 #pragma once
 
 #include <atomic>

--- a/include/kcenon/monitoring/reliability/retry_policy.h
+++ b/include/kcenon/monitoring/reliability/retry_policy.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file retry_policy.h
+ * @brief Retry strategies with backoff for monitoring operations.
+ *
+ */
+
 #pragma once
 
 #include <algorithm>

--- a/include/kcenon/monitoring/storage/storage_backends.h
+++ b/include/kcenon/monitoring/storage/storage_backends.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file storage_backends.h
+ * @brief Storage backend type definitions for metric persistence.
+ *
+ */
+
 #pragma once
 
 #include <string>

--- a/include/kcenon/monitoring/tracing/trace_context.h
+++ b/include/kcenon/monitoring/tracing/trace_context.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file trace_context.h
+ * @brief W3C-style trace context with trace_id, span_id, and parent propagation.
+ *
+ * @see distributed_tracer
+ */
+
 #pragma once
 #include <string>
 #include <chrono>


### PR DESCRIPTION
## Summary

Add `@file` Doxygen documentation blocks to 23 public API headers that were missing them, achieving 100% `@file` coverage across all headers in monitoring_system.

### Directories Updated
- `adapters/` — common_to_monitoring, logger_to_monitoring, monitor, monitoring_to_common, thread_to_monitoring adapters
- `collectors/` — logger_system, plugin_metric, system_resource, thread_system collectors
- `core/` — central_collector, performance_types, safe_event_dispatcher
- `optimization/` — lockfree_queue, memory_pool, simd_aggregator
- `reliability/` — data_consistency, error_boundary, fault_tolerance_manager, graceful_degradation, resource_manager, retry_policy
- `storage/` — storage_backends
- `tracing/` — trace_context

Closes #568

## Test Plan
- [ ] Verify Doxygen generation produces no warnings on updated headers
- [ ] Confirm existing CI checks pass