### PR TITLE
docs: fix traceability matrix doc_id collision with production quality

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@ Total documents: **80**
 | 64 | MON-INTR-004 | OpenTelemetry Collector Sidecar Pattern | [OTEL_COLLECTOR_SIDECAR.md](./guides/OTEL_COLLECTOR_SIDECAR.md) | Released |
 | 65 | MON-QUAL-001 | Monitoring System - 프로덕션 품질 메트릭 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | 66 | MON-QUAL-002 | Monitoring System - Production Quality Metrics | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| 67 | MON-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| 67 | MON-QUAL-005 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 | 68 | MON-QUAL-003 | Testing Guide | [TESTING_GUIDE.md](./contributing/TESTING_GUIDE.md) | Released |
 | 69 | MON-QUAL-004 | Reliability Patterns Usage Guide | [RELIABILITY_PATTERNS.md](./guides/RELIABILITY_PATTERNS.md) | Released |
 | 70 | MON-SECU-001 | 보안 정책 | [SECURITY.kr.md](./guides/SECURITY.kr.md) | Released |
@@ -207,7 +207,7 @@ Total documents: **80**
 |--------|-------|----------|--------|
 | MON-QUAL-001 | Monitoring System - 프로덕션 품질 메트릭 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | MON-QUAL-002 | Monitoring System - Production Quality Metrics | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| MON-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| MON-QUAL-005 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 | MON-QUAL-003 | Testing Guide | [TESTING_GUIDE.md](./contributing/TESTING_GUIDE.md) | Released |
 | MON-QUAL-004 | Reliability Patterns Usage Guide | [RELIABILITY_PATTERNS.md](./guides/RELIABILITY_PATTERNS.md) | Released |
 

--- a/docs/TRACEABILITY.md
+++ b/docs/TRACEABILITY.md
@@ -1,5 +1,5 @@
 ---
-doc_id: "MON-QUAL-002"
+doc_id: "MON-QUAL-005"
 doc_title: "Feature-Test-Module Traceability Matrix"
 doc_version: "1.0.0"
 doc_date: "2026-04-04"


### PR DESCRIPTION
## Summary

- Fix doc_id collision: `TRACEABILITY.md` and `PRODUCTION_QUALITY.md` both used `MON-QUAL-002`
- Assign unique `MON-QUAL-005` to `TRACEABILITY.md` (next available QUAL number)
- Update SSOT registry (`docs/README.md`) to reflect the corrected doc_id

Related to kcenon/common_system#566

## What

The traceability matrix document (`docs/TRACEABILITY.md`) was sharing `MON-QUAL-002` with `PRODUCTION_QUALITY.md`. Each document in the SSOT registry must have a unique `doc_id`. This PR assigns `MON-QUAL-005` to the traceability matrix.

## How

- Updated `doc_id` in `docs/TRACEABILITY.md` YAML frontmatter from `MON-QUAL-002` to `MON-QUAL-005`
- Updated both entries in `docs/README.md` (numbered table and category index)

## Test Plan

- [x] Verify `MON-QUAL-005` is not used by any other document
- [x] Verify TRACEABILITY.md YAML frontmatter matches README.md registry entry
- [x] Verify all feature-test mappings are accurate (test files exist)
- [x] Verify coverage summary totals match actual feature count (54)