### PR TITLE
fix(build): add warnings when MONITORING_CAN_INSTALL is FALSE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -673,6 +673,9 @@ if(MONITORING_WITH_THREAD_SYSTEM)
         get_target_property(_thread_imported ${MONITORING_THREAD_TARGET} IMPORTED)
         if(NOT _thread_imported)
             set(MONITORING_CAN_INSTALL FALSE)
+            message(WARNING "monitoring_system: Installation disabled because '${MONITORING_THREAD_TARGET}' is not an IMPORTED target. "
+                            "This typically happens when dependencies are added via add_subdirectory() instead of find_package(). "
+                            "vcpkg builds require IMPORTED targets for proper packaging.")
         endif()
     else()
         message(FATAL_ERROR "MONITORING_WITH_THREAD_SYSTEM is ON but no thread_system target found.")
@@ -686,6 +689,9 @@ if(MONITORING_WITH_LOGGER_SYSTEM)
         get_target_property(_logger_imported ${MONITORING_LOGGER_TARGET} IMPORTED)
         if(NOT _logger_imported)
             set(MONITORING_CAN_INSTALL FALSE)
+            message(WARNING "monitoring_system: Installation disabled because '${MONITORING_LOGGER_TARGET}' is not an IMPORTED target. "
+                            "This typically happens when dependencies are added via add_subdirectory() instead of find_package(). "
+                            "vcpkg builds require IMPORTED targets for proper packaging.")
         endif()
     else()
         message(STATUS "MONITORING_WITH_LOGGER_SYSTEM is ON but no logger_system target found. "
@@ -701,6 +707,9 @@ if(MONITORING_WITH_NETWORK_SYSTEM)
         get_target_property(_network_imported ${MONITORING_NETWORK_TARGET} IMPORTED)
         if(NOT _network_imported)
             set(MONITORING_CAN_INSTALL FALSE)
+            message(WARNING "monitoring_system: Installation disabled because '${MONITORING_NETWORK_TARGET}' is not an IMPORTED target. "
+                            "This typically happens when dependencies are added via add_subdirectory() instead of find_package(). "
+                            "vcpkg builds require IMPORTED targets for proper packaging.")
         endif()
     elseif(DEFINED NETWORK_SYSTEM_INCLUDE_DIR)
         # Header-only integration
@@ -893,7 +902,8 @@ if(MONITORING_CAN_INSTALL)
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/monitoring_system
     )
 else()
-    message(STATUS "Monitoring System: Skipping install/export (subdirectory build with non-IMPORTED deps)")
+    message(WARNING "monitoring_system: Skipping install rules because MONITORING_CAN_INSTALL is FALSE. "
+                    "Package will not produce installed files.")
 endif()
 
 


### PR DESCRIPTION
## What

### Summary
When dependencies are non-IMPORTED targets (added via `add_subdirectory()` instead of `find_package()`), `MONITORING_CAN_INSTALL` is silently set to `FALSE`, causing the install/export block to be skipped entirely. This produces a vcpkg package with **no installed files** and no diagnostic output in the build log.

This PR adds `message(WARNING ...)` at each location where the flag is disabled, so the build log clearly identifies which dependency caused installation to be skipped.

### Change Type
- [ ] Feature (new functionality)
- [x] Bugfix (fixes an issue)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Test

### Affected Components
- `CMakeLists.txt` — dependency linking and install gate sections

## Why

### Problem Solved
Silent packaging failures in vcpkg builds. When `MONITORING_CAN_INSTALL` is `FALSE`, the only existing log line was a `STATUS` message in the else branch that could easily be missed. Users had no way to determine **which** dependency caused the install rules to be skipped.

### Related Issues
- Closes #655

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `CMakeLists.txt` | Added 3 WARNING messages at set-to-FALSE sites + upgraded else branch from STATUS to WARNING |

## How

### Implementation Details
1. Added `message(WARNING ...)` after each of the 3 locations where `MONITORING_CAN_INSTALL` is set to `FALSE` (thread_system, logger_system, network_system dependency checks)
2. Each warning identifies the specific target name that is not IMPORTED and explains the root cause (add_subdirectory vs find_package)
3. Upgraded the install-block else branch from `message(STATUS ...)` to `message(WARNING ...)` so the skip is visible in build logs

### Testing Done
- [x] Verified changes are warning-only (no logic changes)
- [x] Reviewed all 3 dependency check blocks for consistent messaging

### Breaking Changes
None — diagnostic messages only, no behavioral changes.