### PR TITLE
build(install): adopt tiered install degradation pattern

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -734,6 +734,27 @@ if(MONITORING_WITH_NETWORK_SYSTEM)
     endif()
 endif()
 
+# Collect non-IMPORTED dependency names for diagnostic messages
+set(_MONITORING_NON_IMPORTED_DEPS "")
+if(MONITORING_WITH_THREAD_SYSTEM AND MONITORING_THREAD_TARGET AND TARGET ${MONITORING_THREAD_TARGET})
+    get_target_property(_imp ${MONITORING_THREAD_TARGET} IMPORTED)
+    if(NOT _imp)
+        list(APPEND _MONITORING_NON_IMPORTED_DEPS "${MONITORING_THREAD_TARGET}")
+    endif()
+endif()
+if(MONITORING_WITH_LOGGER_SYSTEM AND MONITORING_LOGGER_TARGET AND TARGET ${MONITORING_LOGGER_TARGET})
+    get_target_property(_imp ${MONITORING_LOGGER_TARGET} IMPORTED)
+    if(NOT _imp)
+        list(APPEND _MONITORING_NON_IMPORTED_DEPS "${MONITORING_LOGGER_TARGET}")
+    endif()
+endif()
+if(MONITORING_WITH_NETWORK_SYSTEM AND MONITORING_NETWORK_TARGET AND TARGET ${MONITORING_NETWORK_TARGET})
+    get_target_property(_imp ${MONITORING_NETWORK_TARGET} IMPORTED)
+    if(NOT _imp)
+        list(APPEND _MONITORING_NON_IMPORTED_DEPS "${MONITORING_NETWORK_TARGET}")
+    endif()
+endif()
+
 if(MONITORING_WITH_GRPC)
     if(MONITORING_GRPC_TARGET AND TARGET ${MONITORING_GRPC_TARGET})
         target_link_libraries(monitoring_system PUBLIC ${MONITORING_GRPC_TARGET})
@@ -857,66 +878,82 @@ if(MONITORING_BUILD_INTEGRATION_TESTS)
     endif()
 endif()
 
-if(MONITORING_CAN_INSTALL)
-    # Installation — only when all dependency targets are IMPORTED (find_package / vcpkg).
-    # Subdirectory builds set MONITORING_CAN_INSTALL=FALSE because CMake cannot export
-    # non-IMPORTED dependency targets (e.g. "utilities" from common_system).
-    include(GNUInstallDirs)
+# Tiered Install Degradation
+# Tier 1 (headers) and Tier 4 (config) always install.
+# Tier 2 (library targets) always installs.
+# Tier 3 (install(EXPORT) + export(EXPORT)) is conditional on all PUBLIC deps being IMPORTED.
+include(GNUInstallDirs)
 
+# --- Tier 1: Headers (ALWAYS) ---
+install(DIRECTORY include/kcenon/monitoring
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon
+    FILES_MATCHING PATTERN "*.h"
+)
+
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/common_adapters.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/thread_adapters.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/logger_adapters.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/common_to_monitoring_adapter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/monitoring_to_common_adapter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/thread_to_monitoring_adapter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/logger_to_monitoring_adapter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/monitor_adapter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/performance_monitor_adapter.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon/monitoring/adapters
+    COMPONENT Development
+)
+
+# --- Tier 2+3: Targets + conditional EXPORT ---
+if(MONITORING_CAN_INSTALL)
+    # Tier 2: Library targets with EXPORT set
     install(TARGETS monitoring_system monitoring_system_interface
         EXPORT monitoring_system_targets
     )
 
-    install(DIRECTORY include/kcenon/monitoring
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon
-        FILES_MATCHING PATTERN "*.h"
-    )
-
+    # Tier 3: Export sets (requires all PUBLIC deps to be IMPORTED)
     install(EXPORT monitoring_system_targets
         FILE monitoring_system-targets.cmake
         NAMESPACE monitoring_system::
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/monitoring_system
     )
 
-    # Create package configuration
-    include(CMakePackageConfigHelpers)
-
-    configure_package_config_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/monitoring_system-config.cmake.in
-        ${CMAKE_CURRENT_BINARY_DIR}/monitoring_system-config.cmake
-        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/monitoring_system
-    )
-
-    write_basic_package_version_file(
-        ${CMAKE_CURRENT_BINARY_DIR}/monitoring_system-config-version.cmake
-        VERSION ${PROJECT_VERSION}
-        COMPATIBILITY SameMajorVersion
-    )
-
-    # Install adapter headers
-    install(FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/common_adapters.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/thread_adapters.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/logger_adapters.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/common_to_monitoring_adapter.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/monitoring_to_common_adapter.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/thread_to_monitoring_adapter.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/logger_to_monitoring_adapter.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/monitor_adapter.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/performance_monitor_adapter.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon/monitoring/adapters
-        COMPONENT Development
-    )
-
-    install(FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/monitoring_system-config.cmake
-        ${CMAKE_CURRENT_BINARY_DIR}/monitoring_system-config-version.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/monitoring_system
+    export(EXPORT monitoring_system_targets
+        FILE "${CMAKE_CURRENT_BINARY_DIR}/monitoring_system-targets.cmake"
+        NAMESPACE monitoring_system::
     )
 else()
-    message(WARNING "monitoring_system: Skipping install rules because MONITORING_CAN_INSTALL is FALSE. "
-                    "Package will not produce installed files.")
+    # Tier 2 fallback: Library targets without EXPORT
+    install(TARGETS monitoring_system monitoring_system_interface
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+
+    message(STATUS "monitoring_system: install(EXPORT) skipped — non-IMPORTED deps: "
+                   "${_MONITORING_NON_IMPORTED_DEPS}. Headers and libraries are installed.")
 endif()
+
+# --- Tier 4: Config + version files (ALWAYS) ---
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/monitoring_system-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/monitoring_system-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/monitoring_system
+)
+
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/monitoring_system-config-version.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/monitoring_system-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/monitoring_system-config-version.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/monitoring_system
+)
 
 
 

--- a/cmake/monitoring_system-config.cmake.in
+++ b/cmake/monitoring_system-config.cmake.in
@@ -74,8 +74,10 @@ unset(MONITORING_USE_LOGGER_SYSTEM)
 unset(MONITORING_USE_NETWORK_SYSTEM)
 unset(MONITORING_USE_GRPC)
 
-# Include targets
-include("${CMAKE_CURRENT_LIST_DIR}/monitoring_system-targets.cmake")
+# Include targets (guarded: targets file is absent when EXPORT was skipped)
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/monitoring_system-targets.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/monitoring_system-targets.cmake")
+endif()
 
 # Verify targets exist
 check_required_components(monitoring_system)


### PR DESCRIPTION
Closes #661

## What

### Summary
Restructures the CMake install section to adopt the **Tiered Install Degradation** pattern.
Previously, when `MONITORING_CAN_INSTALL=FALSE` (any dependency is non-IMPORTED), the entire
install section was skipped — including headers, adapter headers, config files, and library
targets. Now only `install(EXPORT)` and `export(EXPORT)` are conditional.

### Change Type
- [x] Enhancement (improved existing functionality)
- [ ] Feature (new functionality)
- [ ] Bugfix
- [ ] Refactor

### Affected Components
- `CMakeLists.txt` — install section restructured, dep name collection added
- `cmake/monitoring_system-config.cmake.in` — `EXISTS` guard on targets include

## Why

### Problem Solved
In subdirectory builds (e.g., via `add_subdirectory()`), zero files were installed — not
even headers. The warning message was generic ("Skipping install rules") without naming
which dependency caused the issue.

### Related Issues
- Closes #661 (adopt Tiered Install Degradation pattern)
- Cross-ref: kcenon/vcpkg-registry#69 (portfile update needed for the `EXISTS` guard change)

### Note on vcpkg-registry
The vcpkg portfile (`vcpkg-registry/ports/kcenon-monitoring-system/portfile.cmake:72-79`)
uses `vcpkg_replace_string` targeting the exact text
`include("${CMAKE_CURRENT_LIST_DIR}/monitoring_system-targets.cmake")`.
After this change, the portfile must be updated to match the new `if(EXISTS ...)` block.
See kcenon/vcpkg-registry#69.

## Where

### Files Changed
| File | Change |
|------|--------|
| `CMakeLists.txt` | Added `_MONITORING_NON_IMPORTED_DEPS` list collection; restructured install into 4 tiers |
| `cmake/monitoring_system-config.cmake.in` | Added `if(EXISTS ...)` guard around targets include |

## How

### Implementation Details

**Tier 1 (ALWAYS)**: Public headers via `install(DIRECTORY ...)` and adapter headers
via `install(FILES ...)` moved outside the `MONITORING_CAN_INSTALL` gate.

**Tier 2+3 (conditional)**:
- When `MONITORING_CAN_INSTALL=TRUE`: targets installed with `EXPORT`, plus
  `install(EXPORT ...)` and `export(EXPORT ...)` for CMake package support.
- When `MONITORING_CAN_INSTALL=FALSE`: targets installed without EXPORT (plain
  `LIBRARY`/`ARCHIVE`/`RUNTIME` destinations). Specific diagnostic message names
  `${_MONITORING_NON_IMPORTED_DEPS}`.

**Tier 4 (ALWAYS)**: `configure_package_config_file()`, `write_basic_package_version_file()`,
and their install rules moved outside the gate.

**Config template**: `include(targets.cmake)` wrapped in `if(EXISTS ...)` so
`find_package(monitoring_system)` succeeds even without the targets file.

### Testing Done
- [x] Code review of all tiers
- [ ] CI multi-platform build (pending)

### Breaking Changes
None. vcpkg builds produce identical output. Subdirectory builds now install more files
(headers, libraries, config) where previously nothing was installed.