### PR TITLE
fix(cmake): add missing DESTINATION clauses to install(TARGETS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -909,6 +909,10 @@ if(MONITORING_CAN_INSTALL)
     # Tier 2: Library targets with EXPORT set
     install(TARGETS monitoring_system monitoring_system_interface
         EXPORT monitoring_system_targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 
     # Tier 3: Export sets (requires all PUBLIC deps to be IMPORTED)


### PR DESCRIPTION
## What

### Summary
Add missing `LIBRARY`, `ARCHIVE`, `RUNTIME`, and `INCLUDES` DESTINATION clauses to the
primary `install(TARGETS)` block in `CMakeLists.txt`.

### Change Type
- [x] Bugfix (fixes an issue)

## Why

### Related Issues
- Part of kcenon/vcpkg-registry#80

### Motivation
The primary install path (`MONITORING_CAN_INSTALL=TRUE`) omitted DESTINATION clauses from
`install(TARGETS)`, causing CMake to use default install locations. These defaults may not
match vcpkg's expected layout (`lib/`, `bin/`, `include/`), leading to install failures or
misplaced artifacts when consuming the package through vcpkg.

The fallback path (when `MONITORING_CAN_INSTALL=FALSE`) already had correct DESTINATION
clauses — this fix brings the primary path to parity.

## Where

### Files Changed
| File | Change |
|------|--------|
| `CMakeLists.txt` (line ~910) | Added 4 DESTINATION clauses to `install(TARGETS)` |

### Before
```cmake
install(TARGETS monitoring_system monitoring_system_interface
    EXPORT monitoring_system_targets
)
```

### After
```cmake
install(TARGETS monitoring_system monitoring_system_interface
    EXPORT monitoring_system_targets
    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
)
```

## How

### Implementation Details
- `GNUInstallDirs` is already included at line 885, providing `CMAKE_INSTALL_LIBDIR`,
  `CMAKE_INSTALL_BINDIR`, and `CMAKE_INSTALL_INCLUDEDIR` variables
- The fallback install path (line ~930) was NOT modified — it already specifies correct destinations
- Only the primary install path was changed to match the fallback's explicit layout

### Testing
- Verified `include(GNUInstallDirs)` is called before the install block
- Verified the fallback path remains unchanged
- CI will validate the full build and install flow