### PR TITLE
feat(exporters): complete Jaeger/Zipkin protobuf serialization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,11 @@ network_system   (Tier 4) [optional] — HTTP transport for exporters
 
 - C++20 required; GCC 13+, Clang 17+, MSVC 2022+, Apple Clang 14+
 - Build requires sibling repos: common_system, thread_system must be cloned alongside
-- Jaeger/Zipkin protobuf serialization still stub implementations
+- Jaeger (`Batch`/`Span`) and Zipkin (`ListOfSpans`/`Span`) protobuf wire formats
+  are implemented via a zero-dependency encoder in
+  `include/kcenon/monitoring/exporters/internal/`; full end-to-end Docker
+  integration tests against jaegertracing/all-in-one and openzipkin/zipkin
+  containers remain a follow-up
 - Some tests have platform-specific timing sensitivity (macOS sleep adjustments)
 - C++20 modules experimental (CMake 3.28+)
 - Hardware/container plugins disabled by default; Kubernetes support is stub

--- a/include/kcenon/monitoring/exporters/internal/jaeger_proto.h
+++ b/include/kcenon/monitoring/exporters/internal/jaeger_proto.h
@@ -1,0 +1,439 @@
+#pragma once
+
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file jaeger_proto.h
+ * @brief Serialization/deserialization of Jaeger api_v2 model.proto messages.
+ *
+ * Implements the minimal subset of `jaeger.api_v2` required to POST spans
+ * to a Jaeger collector. Field numbers match jaegertracing/jaeger-idl
+ * `proto/api_v2/model.proto`:
+ *   KeyValue:  key=1, v_type=2, v_str=3, v_bool=4, v_int64=5, v_float64=6, v_binary=7
+ *   Log:       timestamp=1, fields=2
+ *   SpanRef:   trace_id=1, span_id=2, ref_type=3
+ *   Process:   service_name=1, tags=2
+ *   Span:      trace_id=1, span_id=2, operation_name=3, references=4, flags=5,
+ *              start_time=6, duration=7, tags=8, logs=9, process=10
+ *   Batch:     spans=1, process=2
+ *
+ * google.protobuf.Timestamp: seconds=1 (int64), nanos=2 (int32)
+ * google.protobuf.Duration:  seconds=1 (int64), nanos=2 (int32)
+ */
+
+#include "protobuf_wire.h"
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace kcenon { namespace monitoring { namespace jaeger_proto {
+
+enum class value_type : std::int32_t {
+    string_type  = 0,
+    bool_type    = 1,
+    int64_type   = 2,
+    float64_type = 3,
+    binary_type  = 4,
+};
+
+struct key_value {
+    std::string key;
+    value_type v_type{value_type::string_type};
+    std::string v_str;
+    bool v_bool{false};
+    std::int64_t v_int64{0};
+    double v_float64{0.0};
+    std::vector<std::uint8_t> v_binary;
+};
+
+struct process {
+    std::string service_name;
+    std::vector<key_value> tags;
+};
+
+struct span_ref {
+    std::vector<std::uint8_t> trace_id;
+    std::vector<std::uint8_t> span_id;
+    std::int32_t ref_type{0};  // 0 = CHILD_OF, 1 = FOLLOWS_FROM
+};
+
+struct span {
+    std::vector<std::uint8_t> trace_id;   // 16 bytes on the wire
+    std::vector<std::uint8_t> span_id;    // 8 bytes on the wire
+    std::string operation_name;
+    std::vector<span_ref> references;
+    std::uint32_t flags{0};
+    std::int64_t start_time_seconds{0};
+    std::int32_t start_time_nanos{0};
+    std::int64_t duration_seconds{0};
+    std::int32_t duration_nanos{0};
+    std::vector<key_value> tags;
+    // Logs omitted from this minimal encoder (not produced by the current
+    // span data model). The decoder skips unknown fields safely.
+    process proc;
+};
+
+struct batch {
+    std::vector<span> spans;
+    process proc;
+    bool has_process{false};
+};
+
+// ---------------------------------------------------------------------------
+// Encoders
+// ---------------------------------------------------------------------------
+
+inline std::vector<std::uint8_t> encode_timestamp(std::int64_t seconds,
+                                                  std::int32_t nanos) {
+    std::vector<std::uint8_t> out;
+    protobuf_wire::encode_uint64_field(out, 1, static_cast<std::uint64_t>(seconds));
+    protobuf_wire::encode_uint64_field(out, 2, static_cast<std::uint64_t>(nanos));
+    return out;
+}
+
+inline std::vector<std::uint8_t> encode_duration(std::int64_t seconds,
+                                                 std::int32_t nanos) {
+    std::vector<std::uint8_t> out;
+    protobuf_wire::encode_uint64_field(out, 1, static_cast<std::uint64_t>(seconds));
+    protobuf_wire::encode_uint64_field(out, 2, static_cast<std::uint64_t>(nanos));
+    return out;
+}
+
+inline std::vector<std::uint8_t> encode_key_value(const key_value& kv) {
+    std::vector<std::uint8_t> out;
+    protobuf_wire::encode_string_field(out, 1, kv.key);
+    protobuf_wire::encode_enum_field(out, 2, static_cast<std::int32_t>(kv.v_type));
+    protobuf_wire::encode_string_field(out, 3, kv.v_str);
+    protobuf_wire::encode_bool_field(out, 4, kv.v_bool);
+    if (kv.v_int64 != 0) {
+        protobuf_wire::encode_tag(out, 5, protobuf_wire::wire_type::varint);
+        protobuf_wire::encode_varint(out, static_cast<std::uint64_t>(kv.v_int64));
+    }
+    if (kv.v_float64 != 0.0) {
+        std::uint64_t bits;
+        static_assert(sizeof(bits) == sizeof(kv.v_float64),
+                      "double must be 64 bits");
+        std::memcpy(&bits, &kv.v_float64, sizeof(bits));
+        protobuf_wire::encode_tag(out, 6, protobuf_wire::wire_type::fixed64);
+        protobuf_wire::encode_fixed64(out, bits);
+    }
+    protobuf_wire::encode_bytes_field(out, 7, kv.v_binary);
+    return out;
+}
+
+inline std::vector<std::uint8_t> encode_process(const process& p) {
+    std::vector<std::uint8_t> out;
+    protobuf_wire::encode_string_field(out, 1, p.service_name);
+    for (const auto& tag : p.tags) {
+        auto serialized = encode_key_value(tag);
+        protobuf_wire::encode_message_field(out, 2, serialized);
+    }
+    return out;
+}
+
+inline std::vector<std::uint8_t> encode_span_ref(const span_ref& ref) {
+    std::vector<std::uint8_t> out;
+    protobuf_wire::encode_bytes_field(out, 1, ref.trace_id);
+    protobuf_wire::encode_bytes_field(out, 2, ref.span_id);
+    protobuf_wire::encode_enum_field(out, 3, ref.ref_type);
+    return out;
+}
+
+inline std::vector<std::uint8_t> encode_span(const span& s) {
+    std::vector<std::uint8_t> out;
+    protobuf_wire::encode_bytes_field(out, 1, s.trace_id);
+    protobuf_wire::encode_bytes_field(out, 2, s.span_id);
+    protobuf_wire::encode_string_field(out, 3, s.operation_name);
+    for (const auto& ref : s.references) {
+        auto serialized = encode_span_ref(ref);
+        protobuf_wire::encode_message_field(out, 4, serialized);
+    }
+    protobuf_wire::encode_uint64_field(out, 5, s.flags);
+    if (s.start_time_seconds != 0 || s.start_time_nanos != 0) {
+        auto ts = encode_timestamp(s.start_time_seconds, s.start_time_nanos);
+        protobuf_wire::encode_message_field(out, 6, ts);
+    }
+    if (s.duration_seconds != 0 || s.duration_nanos != 0) {
+        auto du = encode_duration(s.duration_seconds, s.duration_nanos);
+        protobuf_wire::encode_message_field(out, 7, du);
+    }
+    for (const auto& tag : s.tags) {
+        auto serialized = encode_key_value(tag);
+        protobuf_wire::encode_message_field(out, 8, serialized);
+    }
+    if (!s.proc.service_name.empty() || !s.proc.tags.empty()) {
+        auto serialized = encode_process(s.proc);
+        protobuf_wire::encode_message_field(out, 10, serialized);
+    }
+    return out;
+}
+
+inline std::vector<std::uint8_t> encode_batch(const batch& b) {
+    std::vector<std::uint8_t> out;
+    for (const auto& s : b.spans) {
+        auto serialized = encode_span(s);
+        protobuf_wire::encode_message_field(out, 1, serialized);
+    }
+    if (b.has_process) {
+        auto serialized = encode_process(b.proc);
+        protobuf_wire::encode_message_field(out, 2, serialized);
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Decoders (used by round-trip tests)
+// ---------------------------------------------------------------------------
+
+inline bool decode_key_value(const std::uint8_t* data, std::size_t size,
+                             key_value& out) {
+    protobuf_wire::reader r(data, size);
+    while (!r.eof()) {
+        std::uint32_t field_number;
+        protobuf_wire::wire_type wt;
+        if (!protobuf_wire::decode_tag(r, field_number, wt)) return false;
+        switch (field_number) {
+            case 1:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_string(out.key)) return false;
+                break;
+            case 2: {
+                if (wt != protobuf_wire::wire_type::varint) return false;
+                auto v = r.read_varint();
+                if (!v) return false;
+                out.v_type = static_cast<value_type>(*v);
+                break;
+            }
+            case 3:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_string(out.v_str)) return false;
+                break;
+            case 4: {
+                if (wt != protobuf_wire::wire_type::varint) return false;
+                auto v = r.read_varint();
+                if (!v) return false;
+                out.v_bool = (*v != 0);
+                break;
+            }
+            case 5: {
+                if (wt != protobuf_wire::wire_type::varint) return false;
+                auto v = r.read_varint();
+                if (!v) return false;
+                out.v_int64 = static_cast<std::int64_t>(*v);
+                break;
+            }
+            case 6: {
+                if (wt != protobuf_wire::wire_type::fixed64) return false;
+                auto v = r.read_fixed64();
+                if (!v) return false;
+                std::uint64_t bits = *v;
+                std::memcpy(&out.v_float64, &bits, sizeof(out.v_float64));
+                break;
+            }
+            case 7:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_bytes(out.v_binary)) return false;
+                break;
+            default:
+                if (!r.skip_field(wt)) return false;
+        }
+    }
+    return true;
+}
+
+inline bool decode_process(const std::uint8_t* data, std::size_t size,
+                           process& out) {
+    protobuf_wire::reader r(data, size);
+    while (!r.eof()) {
+        std::uint32_t field_number;
+        protobuf_wire::wire_type wt;
+        if (!protobuf_wire::decode_tag(r, field_number, wt)) return false;
+        switch (field_number) {
+            case 1:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_string(out.service_name)) return false;
+                break;
+            case 2: {
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                const std::uint8_t* ptr; std::size_t len;
+                if (!r.read_length_delimited(&ptr, &len)) return false;
+                key_value kv;
+                if (!decode_key_value(ptr, len, kv)) return false;
+                out.tags.push_back(std::move(kv));
+                break;
+            }
+            default:
+                if (!r.skip_field(wt)) return false;
+        }
+    }
+    return true;
+}
+
+inline bool decode_timestamp(const std::uint8_t* data, std::size_t size,
+                             std::int64_t& seconds, std::int32_t& nanos) {
+    protobuf_wire::reader r(data, size);
+    seconds = 0; nanos = 0;
+    while (!r.eof()) {
+        std::uint32_t field_number;
+        protobuf_wire::wire_type wt;
+        if (!protobuf_wire::decode_tag(r, field_number, wt)) return false;
+        if (wt != protobuf_wire::wire_type::varint) {
+            if (!r.skip_field(wt)) return false;
+            continue;
+        }
+        auto v = r.read_varint();
+        if (!v) return false;
+        if (field_number == 1) seconds = static_cast<std::int64_t>(*v);
+        else if (field_number == 2) nanos = static_cast<std::int32_t>(*v);
+    }
+    return true;
+}
+
+inline bool decode_span_ref(const std::uint8_t* data, std::size_t size,
+                            span_ref& out) {
+    protobuf_wire::reader r(data, size);
+    while (!r.eof()) {
+        std::uint32_t field_number;
+        protobuf_wire::wire_type wt;
+        if (!protobuf_wire::decode_tag(r, field_number, wt)) return false;
+        switch (field_number) {
+            case 1:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_bytes(out.trace_id)) return false;
+                break;
+            case 2:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_bytes(out.span_id)) return false;
+                break;
+            case 3: {
+                if (wt != protobuf_wire::wire_type::varint) return false;
+                auto v = r.read_varint();
+                if (!v) return false;
+                out.ref_type = static_cast<std::int32_t>(*v);
+                break;
+            }
+            default:
+                if (!r.skip_field(wt)) return false;
+        }
+    }
+    return true;
+}
+
+inline bool decode_span(const std::uint8_t* data, std::size_t size,
+                        span& out) {
+    protobuf_wire::reader r(data, size);
+    while (!r.eof()) {
+        std::uint32_t field_number;
+        protobuf_wire::wire_type wt;
+        if (!protobuf_wire::decode_tag(r, field_number, wt)) return false;
+        switch (field_number) {
+            case 1:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_bytes(out.trace_id)) return false;
+                break;
+            case 2:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_bytes(out.span_id)) return false;
+                break;
+            case 3:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_string(out.operation_name)) return false;
+                break;
+            case 4: {
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                const std::uint8_t* ptr; std::size_t len;
+                if (!r.read_length_delimited(&ptr, &len)) return false;
+                span_ref ref;
+                if (!decode_span_ref(ptr, len, ref)) return false;
+                out.references.push_back(std::move(ref));
+                break;
+            }
+            case 5: {
+                if (wt != protobuf_wire::wire_type::varint) return false;
+                auto v = r.read_varint();
+                if (!v) return false;
+                out.flags = static_cast<std::uint32_t>(*v);
+                break;
+            }
+            case 6: {
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                const std::uint8_t* ptr; std::size_t len;
+                if (!r.read_length_delimited(&ptr, &len)) return false;
+                if (!decode_timestamp(ptr, len,
+                                      out.start_time_seconds,
+                                      out.start_time_nanos))
+                    return false;
+                break;
+            }
+            case 7: {
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                const std::uint8_t* ptr; std::size_t len;
+                if (!r.read_length_delimited(&ptr, &len)) return false;
+                if (!decode_timestamp(ptr, len,
+                                      out.duration_seconds,
+                                      out.duration_nanos))
+                    return false;
+                break;
+            }
+            case 8: {
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                const std::uint8_t* ptr; std::size_t len;
+                if (!r.read_length_delimited(&ptr, &len)) return false;
+                key_value kv;
+                if (!decode_key_value(ptr, len, kv)) return false;
+                out.tags.push_back(std::move(kv));
+                break;
+            }
+            case 10: {
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                const std::uint8_t* ptr; std::size_t len;
+                if (!r.read_length_delimited(&ptr, &len)) return false;
+                if (!decode_process(ptr, len, out.proc)) return false;
+                break;
+            }
+            default:
+                if (!r.skip_field(wt)) return false;
+        }
+    }
+    return true;
+}
+
+inline bool decode_batch(const std::uint8_t* data, std::size_t size,
+                         batch& out) {
+    protobuf_wire::reader r(data, size);
+    while (!r.eof()) {
+        std::uint32_t field_number;
+        protobuf_wire::wire_type wt;
+        if (!protobuf_wire::decode_tag(r, field_number, wt)) return false;
+        switch (field_number) {
+            case 1: {
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                const std::uint8_t* ptr; std::size_t len;
+                if (!r.read_length_delimited(&ptr, &len)) return false;
+                span s;
+                if (!decode_span(ptr, len, s)) return false;
+                out.spans.push_back(std::move(s));
+                break;
+            }
+            case 2: {
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                const std::uint8_t* ptr; std::size_t len;
+                if (!r.read_length_delimited(&ptr, &len)) return false;
+                if (!decode_process(ptr, len, out.proc)) return false;
+                out.has_process = true;
+                break;
+            }
+            default:
+                if (!r.skip_field(wt)) return false;
+        }
+    }
+    return true;
+}
+
+}}}  // namespace kcenon::monitoring::jaeger_proto

--- a/include/kcenon/monitoring/exporters/internal/protobuf_wire.h
+++ b/include/kcenon/monitoring/exporters/internal/protobuf_wire.h
@@ -1,0 +1,344 @@
+#pragma once
+
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file protobuf_wire.h
+ * @brief Zero-dependency protobuf wire-format encoder and decoder primitives.
+ *
+ * Implements just enough of the protobuf3 wire format (varint, fixed64, length-
+ * delimited) to serialize and deserialize Jaeger api_v2 and Zipkin proto3 span
+ * messages without pulling in the full protobuf runtime. Only the wire types
+ * actually exercised by the Jaeger / Zipkin span schemas are implemented.
+ *
+ * References:
+ * - https://protobuf.dev/programming-guides/encoding/
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace kcenon { namespace monitoring { namespace protobuf_wire {
+
+enum class wire_type : std::uint8_t {
+    varint           = 0,  ///< int32/int64/uint32/uint64/sint*/bool/enum
+    fixed64          = 1,  ///< fixed64/sfixed64/double
+    length_delimited = 2,  ///< string/bytes/embedded messages/packed repeated
+    fixed32          = 5   ///< fixed32/sfixed32/float
+};
+
+/**
+ * @brief Encode an unsigned varint into the buffer.
+ */
+inline void encode_varint(std::vector<std::uint8_t>& out, std::uint64_t value) {
+    while (value >= 0x80) {
+        out.push_back(static_cast<std::uint8_t>((value & 0x7F) | 0x80));
+        value >>= 7;
+    }
+    out.push_back(static_cast<std::uint8_t>(value));
+}
+
+/**
+ * @brief Encode a tag (field_number << 3 | wire_type) as a varint.
+ */
+inline void encode_tag(std::vector<std::uint8_t>& out,
+                       std::uint32_t field_number,
+                       wire_type wt) {
+    encode_varint(out,
+                  (static_cast<std::uint64_t>(field_number) << 3) |
+                      static_cast<std::uint64_t>(wt));
+}
+
+/**
+ * @brief Encode a fixed64 little-endian value (used for Zipkin timestamps).
+ */
+inline void encode_fixed64(std::vector<std::uint8_t>& out, std::uint64_t value) {
+    for (int i = 0; i < 8; ++i) {
+        out.push_back(static_cast<std::uint8_t>((value >> (i * 8)) & 0xFF));
+    }
+}
+
+/**
+ * @brief Encode a length-delimited byte sequence.
+ */
+inline void encode_length_delimited(std::vector<std::uint8_t>& out,
+                                    const std::uint8_t* data,
+                                    std::size_t size) {
+    encode_varint(out, static_cast<std::uint64_t>(size));
+    out.insert(out.end(), data, data + size);
+}
+
+/** @brief Encode a string field. */
+inline void encode_string_field(std::vector<std::uint8_t>& out,
+                                std::uint32_t field_number,
+                                const std::string& value) {
+    if (value.empty()) {
+        return;  // proto3 defaults: skip empty string
+    }
+    encode_tag(out, field_number, wire_type::length_delimited);
+    encode_length_delimited(
+        out,
+        reinterpret_cast<const std::uint8_t*>(value.data()),
+        value.size());
+}
+
+/** @brief Encode a bytes field. */
+inline void encode_bytes_field(std::vector<std::uint8_t>& out,
+                               std::uint32_t field_number,
+                               const std::vector<std::uint8_t>& value) {
+    if (value.empty()) {
+        return;  // proto3 defaults: skip empty bytes
+    }
+    encode_tag(out, field_number, wire_type::length_delimited);
+    encode_length_delimited(out, value.data(), value.size());
+}
+
+/** @brief Encode a uint32 / uint64 / int64 varint field (skips zero). */
+inline void encode_uint64_field(std::vector<std::uint8_t>& out,
+                                std::uint32_t field_number,
+                                std::uint64_t value) {
+    if (value == 0) {
+        return;
+    }
+    encode_tag(out, field_number, wire_type::varint);
+    encode_varint(out, value);
+}
+
+/** @brief Encode a uint32 field that is not allowed to be skipped even if zero. */
+inline void encode_uint64_field_always(std::vector<std::uint8_t>& out,
+                                       std::uint32_t field_number,
+                                       std::uint64_t value) {
+    encode_tag(out, field_number, wire_type::varint);
+    encode_varint(out, value);
+}
+
+/** @brief Encode an enum field (always written when nonzero). */
+inline void encode_enum_field(std::vector<std::uint8_t>& out,
+                              std::uint32_t field_number,
+                              std::int32_t value) {
+    if (value == 0) {
+        return;
+    }
+    encode_tag(out, field_number, wire_type::varint);
+    encode_varint(out, static_cast<std::uint64_t>(value));
+}
+
+/** @brief Encode a bool field (proto3 skips false). */
+inline void encode_bool_field(std::vector<std::uint8_t>& out,
+                              std::uint32_t field_number,
+                              bool value) {
+    if (!value) {
+        return;
+    }
+    encode_tag(out, field_number, wire_type::varint);
+    encode_varint(out, 1);
+}
+
+/** @brief Encode a fixed64 field. */
+inline void encode_fixed64_field(std::vector<std::uint8_t>& out,
+                                 std::uint32_t field_number,
+                                 std::uint64_t value) {
+    if (value == 0) {
+        return;
+    }
+    encode_tag(out, field_number, wire_type::fixed64);
+    encode_fixed64(out, value);
+}
+
+/** @brief Encode an embedded message field given its pre-serialized bytes. */
+inline void encode_message_field(std::vector<std::uint8_t>& out,
+                                 std::uint32_t field_number,
+                                 const std::vector<std::uint8_t>& serialized) {
+    encode_tag(out, field_number, wire_type::length_delimited);
+    encode_length_delimited(out, serialized.data(), serialized.size());
+}
+
+// ---------------------------------------------------------------------------
+// Decoder
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Minimal protobuf wire reader used for round-trip tests.
+ */
+class reader {
+public:
+    reader(const std::uint8_t* data, std::size_t size)
+        : data_(data), size_(size), pos_(0) {}
+
+    bool eof() const { return pos_ >= size_; }
+    std::size_t position() const { return pos_; }
+    std::size_t size() const { return size_; }
+
+    std::optional<std::uint64_t> read_varint() {
+        std::uint64_t result = 0;
+        int shift = 0;
+        while (pos_ < size_) {
+            std::uint8_t byte = data_[pos_++];
+            result |= static_cast<std::uint64_t>(byte & 0x7F) << shift;
+            if ((byte & 0x80) == 0) {
+                return result;
+            }
+            shift += 7;
+            if (shift > 63) {
+                return std::nullopt;
+            }
+        }
+        return std::nullopt;
+    }
+
+    std::optional<std::uint64_t> read_fixed64() {
+        if (pos_ + 8 > size_) {
+            return std::nullopt;
+        }
+        std::uint64_t result = 0;
+        for (int i = 0; i < 8; ++i) {
+            result |= static_cast<std::uint64_t>(data_[pos_++]) << (i * 8);
+        }
+        return result;
+    }
+
+    std::optional<std::uint32_t> read_fixed32() {
+        if (pos_ + 4 > size_) {
+            return std::nullopt;
+        }
+        std::uint32_t result = 0;
+        for (int i = 0; i < 4; ++i) {
+            result |= static_cast<std::uint32_t>(data_[pos_++]) << (i * 8);
+        }
+        return result;
+    }
+
+    /**
+     * @brief Read a length-delimited payload. Returns pointer into the
+     *        underlying buffer and the length. The pointer is valid for the
+     *        lifetime of the wrapped buffer.
+     */
+    bool read_length_delimited(const std::uint8_t** out_ptr,
+                               std::size_t* out_len) {
+        auto len = read_varint();
+        if (!len) return false;
+        if (pos_ + *len > size_) return false;
+        *out_ptr = data_ + pos_;
+        *out_len = static_cast<std::size_t>(*len);
+        pos_ += *len;
+        return true;
+    }
+
+    bool read_string(std::string& out) {
+        const std::uint8_t* ptr = nullptr;
+        std::size_t len = 0;
+        if (!read_length_delimited(&ptr, &len)) return false;
+        out.assign(reinterpret_cast<const char*>(ptr), len);
+        return true;
+    }
+
+    bool read_bytes(std::vector<std::uint8_t>& out) {
+        const std::uint8_t* ptr = nullptr;
+        std::size_t len = 0;
+        if (!read_length_delimited(&ptr, &len)) return false;
+        out.assign(ptr, ptr + len);
+        return true;
+    }
+
+    /** @brief Skip a field whose wire type is given. */
+    bool skip_field(wire_type wt) {
+        switch (wt) {
+            case wire_type::varint:
+                return read_varint().has_value();
+            case wire_type::fixed64:
+                return read_fixed64().has_value();
+            case wire_type::length_delimited: {
+                const std::uint8_t* ptr;
+                std::size_t len;
+                return read_length_delimited(&ptr, &len);
+            }
+            case wire_type::fixed32:
+                return read_fixed32().has_value();
+        }
+        return false;
+    }
+
+private:
+    const std::uint8_t* data_;
+    std::size_t size_;
+    std::size_t pos_;
+};
+
+/**
+ * @brief Decode a tag into (field_number, wire_type).
+ */
+inline bool decode_tag(reader& r,
+                       std::uint32_t& field_number,
+                       wire_type& wt) {
+    auto tag = r.read_varint();
+    if (!tag) return false;
+    field_number = static_cast<std::uint32_t>(*tag >> 3);
+    wt = static_cast<wire_type>(*tag & 0x07);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Hex helpers for Jaeger/Zipkin trace and span IDs
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Decode a hexadecimal string into bytes. Odd-length strings are
+ *        zero-padded on the left; non-hex characters yield an empty vector.
+ */
+inline std::vector<std::uint8_t> hex_to_bytes(const std::string& hex) {
+    auto nibble = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+        if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+        return -1;
+    };
+    std::string s = hex;
+    if (s.size() % 2 == 1) {
+        s.insert(s.begin(), '0');
+    }
+    std::vector<std::uint8_t> out;
+    out.reserve(s.size() / 2);
+    for (std::size_t i = 0; i < s.size(); i += 2) {
+        int hi = nibble(s[i]);
+        int lo = nibble(s[i + 1]);
+        if (hi < 0 || lo < 0) {
+            return {};  // invalid; caller treats empty as absent
+        }
+        out.push_back(static_cast<std::uint8_t>((hi << 4) | lo));
+    }
+    return out;
+}
+
+/**
+ * @brief Encode raw bytes as a lowercase hex string.
+ */
+inline std::string bytes_to_hex(const std::vector<std::uint8_t>& bytes) {
+    static const char hex_chars[] = "0123456789abcdef";
+    std::string out;
+    out.reserve(bytes.size() * 2);
+    for (std::uint8_t b : bytes) {
+        out.push_back(hex_chars[(b >> 4) & 0x0F]);
+        out.push_back(hex_chars[b & 0x0F]);
+    }
+    return out;
+}
+
+/**
+ * @brief Left-pad bytes to a target width. Used to normalize 8-byte trace IDs
+ *        to Jaeger's 16-byte on-wire width and similar cases.
+ */
+inline std::vector<std::uint8_t> left_pad(const std::vector<std::uint8_t>& in,
+                                          std::size_t width) {
+    if (in.size() >= width) return in;
+    std::vector<std::uint8_t> out(width, 0);
+    std::memcpy(out.data() + (width - in.size()), in.data(), in.size());
+    return out;
+}
+
+}}}  // namespace kcenon::monitoring::protobuf_wire

--- a/include/kcenon/monitoring/exporters/internal/zipkin_proto.h
+++ b/include/kcenon/monitoring/exporters/internal/zipkin_proto.h
@@ -1,0 +1,371 @@
+#pragma once
+
+// BSD 3-Clause License
+// Copyright (c) 2025
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file zipkin_proto.h
+ * @brief Serialization/deserialization of Zipkin `zipkin.proto` messages.
+ *
+ * Implements the subset of `zipkin.proto3` required for POST /api/v2/spans.
+ * Field numbers match openzipkin/zipkin-api `zipkin.proto`:
+ *   Span:        trace_id=1, parent_id=2, id=3, kind=4, name=5, timestamp=6,
+ *                duration=7, local_endpoint=8, remote_endpoint=9,
+ *                annotations=10, tags=11, debug=12, shared=13
+ *   Endpoint:    service_name=1, ipv4=2, ipv6=3, port=4
+ *   Annotation:  timestamp=1, value=2
+ *   ListOfSpans: spans=1
+ *
+ * Note: `timestamp` is encoded as fixed64 per spec; `duration` is varint uint64.
+ */
+
+#include "protobuf_wire.h"
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace kcenon { namespace monitoring { namespace zipkin_proto {
+
+enum class span_kind : std::int32_t {
+    unspecified = 0,
+    client      = 1,
+    server      = 2,
+    producer    = 3,
+    consumer    = 4,
+};
+
+/** @brief Convert a textual Zipkin kind (e.g. "CLIENT") to its enum value. */
+inline span_kind parse_kind(const std::string& value) {
+    std::string upper;
+    upper.reserve(value.size());
+    for (char c : value) {
+        if (c >= 'a' && c <= 'z') upper.push_back(static_cast<char>(c - 'a' + 'A'));
+        else upper.push_back(c);
+    }
+    if (upper == "CLIENT") return span_kind::client;
+    if (upper == "SERVER") return span_kind::server;
+    if (upper == "PRODUCER") return span_kind::producer;
+    if (upper == "CONSUMER") return span_kind::consumer;
+    return span_kind::unspecified;
+}
+
+struct endpoint {
+    std::string service_name;
+    std::vector<std::uint8_t> ipv4;
+    std::vector<std::uint8_t> ipv6;
+    std::int32_t port{0};
+
+    bool empty() const {
+        return service_name.empty() && ipv4.empty() && ipv6.empty() && port == 0;
+    }
+};
+
+struct annotation {
+    std::uint64_t timestamp{0};  // epoch microseconds
+    std::string value;
+};
+
+struct span {
+    std::vector<std::uint8_t> trace_id;   // 8 or 16 bytes
+    std::vector<std::uint8_t> parent_id;  // 8 bytes (may be empty)
+    std::vector<std::uint8_t> id;         // 8 bytes
+    span_kind kind{span_kind::unspecified};
+    std::string name;
+    std::uint64_t timestamp{0};   // epoch microseconds
+    std::uint64_t duration{0};    // microseconds
+    endpoint local_endpoint;
+    endpoint remote_endpoint;
+    std::vector<annotation> annotations;
+    std::vector<std::pair<std::string, std::string>> tags;  // proto map<string,string>
+    bool debug{false};
+    bool shared{false};
+};
+
+struct list_of_spans {
+    std::vector<span> spans;
+};
+
+// ---------------------------------------------------------------------------
+// Encoders
+// ---------------------------------------------------------------------------
+
+inline std::vector<std::uint8_t> encode_endpoint(const endpoint& ep) {
+    std::vector<std::uint8_t> out;
+    protobuf_wire::encode_string_field(out, 1, ep.service_name);
+    protobuf_wire::encode_bytes_field(out, 2, ep.ipv4);
+    protobuf_wire::encode_bytes_field(out, 3, ep.ipv6);
+    protobuf_wire::encode_uint64_field(out, 4, static_cast<std::uint64_t>(ep.port));
+    return out;
+}
+
+inline std::vector<std::uint8_t> encode_annotation(const annotation& ann) {
+    std::vector<std::uint8_t> out;
+    if (ann.timestamp != 0) {
+        protobuf_wire::encode_tag(out, 1, protobuf_wire::wire_type::fixed64);
+        protobuf_wire::encode_fixed64(out, ann.timestamp);
+    }
+    protobuf_wire::encode_string_field(out, 2, ann.value);
+    return out;
+}
+
+/**
+ * @brief Encode a single entry of a `map<string,string>` field.
+ *
+ * Protobuf encodes map fields as a repeated synthetic message with field 1 =
+ * key and field 2 = value.
+ */
+inline std::vector<std::uint8_t> encode_string_map_entry(const std::string& key,
+                                                        const std::string& value) {
+    std::vector<std::uint8_t> out;
+    protobuf_wire::encode_string_field(out, 1, key);
+    protobuf_wire::encode_string_field(out, 2, value);
+    return out;
+}
+
+inline std::vector<std::uint8_t> encode_span(const span& s) {
+    std::vector<std::uint8_t> out;
+    protobuf_wire::encode_bytes_field(out, 1, s.trace_id);
+    protobuf_wire::encode_bytes_field(out, 2, s.parent_id);
+    protobuf_wire::encode_bytes_field(out, 3, s.id);
+    protobuf_wire::encode_enum_field(out, 4, static_cast<std::int32_t>(s.kind));
+    protobuf_wire::encode_string_field(out, 5, s.name);
+    protobuf_wire::encode_fixed64_field(out, 6, s.timestamp);
+    protobuf_wire::encode_uint64_field(out, 7, s.duration);
+    if (!s.local_endpoint.empty()) {
+        auto serialized = encode_endpoint(s.local_endpoint);
+        protobuf_wire::encode_message_field(out, 8, serialized);
+    }
+    if (!s.remote_endpoint.empty()) {
+        auto serialized = encode_endpoint(s.remote_endpoint);
+        protobuf_wire::encode_message_field(out, 9, serialized);
+    }
+    for (const auto& ann : s.annotations) {
+        auto serialized = encode_annotation(ann);
+        protobuf_wire::encode_message_field(out, 10, serialized);
+    }
+    for (const auto& [key, value] : s.tags) {
+        auto entry = encode_string_map_entry(key, value);
+        protobuf_wire::encode_message_field(out, 11, entry);
+    }
+    protobuf_wire::encode_bool_field(out, 12, s.debug);
+    protobuf_wire::encode_bool_field(out, 13, s.shared);
+    return out;
+}
+
+inline std::vector<std::uint8_t> encode_list_of_spans(const list_of_spans& list) {
+    std::vector<std::uint8_t> out;
+    for (const auto& s : list.spans) {
+        auto serialized = encode_span(s);
+        protobuf_wire::encode_message_field(out, 1, serialized);
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Decoders (used by round-trip tests)
+// ---------------------------------------------------------------------------
+
+inline bool decode_endpoint(const std::uint8_t* data, std::size_t size,
+                            endpoint& out) {
+    protobuf_wire::reader r(data, size);
+    while (!r.eof()) {
+        std::uint32_t field_number;
+        protobuf_wire::wire_type wt;
+        if (!protobuf_wire::decode_tag(r, field_number, wt)) return false;
+        switch (field_number) {
+            case 1:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_string(out.service_name)) return false;
+                break;
+            case 2:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_bytes(out.ipv4)) return false;
+                break;
+            case 3:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_bytes(out.ipv6)) return false;
+                break;
+            case 4: {
+                if (wt != protobuf_wire::wire_type::varint) return false;
+                auto v = r.read_varint();
+                if (!v) return false;
+                out.port = static_cast<std::int32_t>(*v);
+                break;
+            }
+            default:
+                if (!r.skip_field(wt)) return false;
+        }
+    }
+    return true;
+}
+
+inline bool decode_annotation(const std::uint8_t* data, std::size_t size,
+                              annotation& out) {
+    protobuf_wire::reader r(data, size);
+    while (!r.eof()) {
+        std::uint32_t field_number;
+        protobuf_wire::wire_type wt;
+        if (!protobuf_wire::decode_tag(r, field_number, wt)) return false;
+        switch (field_number) {
+            case 1: {
+                if (wt != protobuf_wire::wire_type::fixed64) return false;
+                auto v = r.read_fixed64();
+                if (!v) return false;
+                out.timestamp = *v;
+                break;
+            }
+            case 2:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_string(out.value)) return false;
+                break;
+            default:
+                if (!r.skip_field(wt)) return false;
+        }
+    }
+    return true;
+}
+
+inline bool decode_map_entry(const std::uint8_t* data, std::size_t size,
+                             std::string& key, std::string& value) {
+    protobuf_wire::reader r(data, size);
+    while (!r.eof()) {
+        std::uint32_t field_number;
+        protobuf_wire::wire_type wt;
+        if (!protobuf_wire::decode_tag(r, field_number, wt)) return false;
+        if (wt != protobuf_wire::wire_type::length_delimited) {
+            if (!r.skip_field(wt)) return false;
+            continue;
+        }
+        if (field_number == 1) {
+            if (!r.read_string(key)) return false;
+        } else if (field_number == 2) {
+            if (!r.read_string(value)) return false;
+        } else {
+            const std::uint8_t* ptr; std::size_t len;
+            if (!r.read_length_delimited(&ptr, &len)) return false;
+        }
+    }
+    return true;
+}
+
+inline bool decode_span(const std::uint8_t* data, std::size_t size, span& out) {
+    protobuf_wire::reader r(data, size);
+    while (!r.eof()) {
+        std::uint32_t field_number;
+        protobuf_wire::wire_type wt;
+        if (!protobuf_wire::decode_tag(r, field_number, wt)) return false;
+        switch (field_number) {
+            case 1:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_bytes(out.trace_id)) return false;
+                break;
+            case 2:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_bytes(out.parent_id)) return false;
+                break;
+            case 3:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_bytes(out.id)) return false;
+                break;
+            case 4: {
+                if (wt != protobuf_wire::wire_type::varint) return false;
+                auto v = r.read_varint();
+                if (!v) return false;
+                out.kind = static_cast<span_kind>(*v);
+                break;
+            }
+            case 5:
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                if (!r.read_string(out.name)) return false;
+                break;
+            case 6: {
+                if (wt != protobuf_wire::wire_type::fixed64) return false;
+                auto v = r.read_fixed64();
+                if (!v) return false;
+                out.timestamp = *v;
+                break;
+            }
+            case 7: {
+                if (wt != protobuf_wire::wire_type::varint) return false;
+                auto v = r.read_varint();
+                if (!v) return false;
+                out.duration = *v;
+                break;
+            }
+            case 8: {
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                const std::uint8_t* ptr; std::size_t len;
+                if (!r.read_length_delimited(&ptr, &len)) return false;
+                if (!decode_endpoint(ptr, len, out.local_endpoint)) return false;
+                break;
+            }
+            case 9: {
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                const std::uint8_t* ptr; std::size_t len;
+                if (!r.read_length_delimited(&ptr, &len)) return false;
+                if (!decode_endpoint(ptr, len, out.remote_endpoint)) return false;
+                break;
+            }
+            case 10: {
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                const std::uint8_t* ptr; std::size_t len;
+                if (!r.read_length_delimited(&ptr, &len)) return false;
+                annotation ann;
+                if (!decode_annotation(ptr, len, ann)) return false;
+                out.annotations.push_back(std::move(ann));
+                break;
+            }
+            case 11: {
+                if (wt != protobuf_wire::wire_type::length_delimited) return false;
+                const std::uint8_t* ptr; std::size_t len;
+                if (!r.read_length_delimited(&ptr, &len)) return false;
+                std::string key, value;
+                if (!decode_map_entry(ptr, len, key, value)) return false;
+                out.tags.emplace_back(std::move(key), std::move(value));
+                break;
+            }
+            case 12: {
+                if (wt != protobuf_wire::wire_type::varint) return false;
+                auto v = r.read_varint();
+                if (!v) return false;
+                out.debug = (*v != 0);
+                break;
+            }
+            case 13: {
+                if (wt != protobuf_wire::wire_type::varint) return false;
+                auto v = r.read_varint();
+                if (!v) return false;
+                out.shared = (*v != 0);
+                break;
+            }
+            default:
+                if (!r.skip_field(wt)) return false;
+        }
+    }
+    return true;
+}
+
+inline bool decode_list_of_spans(const std::uint8_t* data, std::size_t size,
+                                 list_of_spans& out) {
+    protobuf_wire::reader r(data, size);
+    while (!r.eof()) {
+        std::uint32_t field_number;
+        protobuf_wire::wire_type wt;
+        if (!protobuf_wire::decode_tag(r, field_number, wt)) return false;
+        if (field_number == 1 && wt == protobuf_wire::wire_type::length_delimited) {
+            const std::uint8_t* ptr; std::size_t len;
+            if (!r.read_length_delimited(&ptr, &len)) return false;
+            span s;
+            if (!decode_span(ptr, len, s)) return false;
+            out.spans.push_back(std::move(s));
+        } else {
+            if (!r.skip_field(wt)) return false;
+        }
+    }
+    return true;
+}
+
+}}}  // namespace kcenon::monitoring::zipkin_proto

--- a/include/kcenon/monitoring/exporters/trace_exporters.h
+++ b/include/kcenon/monitoring/exporters/trace_exporters.h
@@ -327,11 +327,12 @@ struct zipkin_span_data {
         zipkin_proto::span out;
         auto trace_bytes = protobuf_wire::hex_to_bytes(trace_id);
         // Zipkin accepts 8 or 16 byte trace IDs; normalize the common
-        // shorter cases by padding to 8 bytes.
-        if (!trace_bytes.empty() && trace_bytes.size() != 16) {
-            out.trace_id = protobuf_wire::left_pad(trace_bytes, 8);
+        // shorter/empty/non-hex inputs to 8 bytes so the wire always carries
+        // a valid ID (Zipkin rejects spans without a trace ID).
+        if (trace_bytes.size() == 16) {
+            out.trace_id = std::move(trace_bytes);
         } else {
-            out.trace_id = trace_bytes;
+            out.trace_id = protobuf_wire::left_pad(trace_bytes, 8);
         }
         out.id = protobuf_wire::left_pad(
             protobuf_wire::hex_to_bytes(span_id), 8);
@@ -365,10 +366,10 @@ inline std::vector<uint8_t> encode_zipkin_list_of_spans(
     for (const auto& s : spans) {
         zipkin_proto::span ps;
         auto trace_bytes = protobuf_wire::hex_to_bytes(s.trace_id);
-        if (!trace_bytes.empty() && trace_bytes.size() != 16) {
-            ps.trace_id = protobuf_wire::left_pad(trace_bytes, 8);
+        if (trace_bytes.size() == 16) {
+            ps.trace_id = std::move(trace_bytes);
         } else {
-            ps.trace_id = trace_bytes;
+            ps.trace_id = protobuf_wire::left_pad(trace_bytes, 8);
         }
         ps.id = protobuf_wire::left_pad(
             protobuf_wire::hex_to_bytes(s.span_id), 8);

--- a/include/kcenon/monitoring/exporters/trace_exporters.h
+++ b/include/kcenon/monitoring/exporters/trace_exporters.h
@@ -24,6 +24,8 @@
 #include "opentelemetry_adapter.h"
 #include "http_transport.h"
 #include "grpc_transport.h"
+#include "internal/jaeger_proto.h"
+#include "internal/zipkin_proto.h"
 #include <vector>
 #include <string>
 #include <memory>
@@ -151,14 +153,110 @@ struct jaeger_span_data {
     }
 
     /**
-     * @brief Convert to Jaeger protobuf format (stub)
+     * @brief Convert this span to a Jaeger api_v2 `Span` protobuf message.
+     *
+     * Field numbers follow `jaeger-idl/proto/api_v2/model.proto`. Trace IDs
+     * are zero-padded to 16 bytes and span IDs to 8 bytes, matching the
+     * conventions enforced by the Jaeger collector.
      */
     std::vector<uint8_t> to_protobuf() const {
-        // Protobuf serialization requires generated code
-        // Return empty for now - full implementation would use protobuf library
-        return {};
+        jaeger_proto::span out;
+        out.trace_id = protobuf_wire::left_pad(
+            protobuf_wire::hex_to_bytes(trace_id), 16);
+        out.span_id = protobuf_wire::left_pad(
+            protobuf_wire::hex_to_bytes(span_id), 8);
+        out.operation_name = operation_name;
+
+        if (!parent_span_id.empty()) {
+            jaeger_proto::span_ref ref;
+            ref.trace_id = out.trace_id;
+            ref.span_id = protobuf_wire::left_pad(
+                protobuf_wire::hex_to_bytes(parent_span_id), 8);
+            ref.ref_type = 0;  // CHILD_OF
+            out.references.push_back(std::move(ref));
+        }
+
+        // Timestamp / duration split into (seconds, nanos).
+        auto st_ns = std::chrono::nanoseconds(start_time);
+        out.start_time_seconds = static_cast<std::int64_t>(
+            std::chrono::duration_cast<std::chrono::seconds>(st_ns).count());
+        out.start_time_nanos = static_cast<std::int32_t>(
+            (st_ns - std::chrono::seconds(out.start_time_seconds)).count());
+
+        auto du_ns = std::chrono::nanoseconds(duration);
+        out.duration_seconds = static_cast<std::int64_t>(
+            std::chrono::duration_cast<std::chrono::seconds>(du_ns).count());
+        out.duration_nanos = static_cast<std::int32_t>(
+            (du_ns - std::chrono::seconds(out.duration_seconds)).count());
+
+        for (const auto& [key, value] : tags) {
+            jaeger_proto::key_value kv;
+            kv.key = key;
+            kv.v_type = jaeger_proto::value_type::string_type;
+            kv.v_str = value;
+            out.tags.push_back(std::move(kv));
+        }
+
+        out.proc.service_name = service_name;
+        for (const auto& [key, value] : process_tags) {
+            jaeger_proto::key_value kv;
+            kv.key = key;
+            kv.v_type = jaeger_proto::value_type::string_type;
+            kv.v_str = value;
+            out.proc.tags.push_back(std::move(kv));
+        }
+
+        return jaeger_proto::encode_span(out);
     }
 };
+
+/**
+ * @brief Encode a batch of Jaeger spans (with shared process) into a Jaeger
+ *        api_v2 `Batch` protobuf message.
+ */
+inline std::vector<uint8_t> encode_jaeger_batch(
+    const std::vector<jaeger_span_data>& spans,
+    const std::string& service_name) {
+    jaeger_proto::batch b;
+    b.spans.reserve(spans.size());
+    for (const auto& s : spans) {
+        jaeger_proto::span ps;
+        ps.trace_id = protobuf_wire::left_pad(
+            protobuf_wire::hex_to_bytes(s.trace_id), 16);
+        ps.span_id = protobuf_wire::left_pad(
+            protobuf_wire::hex_to_bytes(s.span_id), 8);
+        ps.operation_name = s.operation_name;
+        if (!s.parent_span_id.empty()) {
+            jaeger_proto::span_ref ref;
+            ref.trace_id = ps.trace_id;
+            ref.span_id = protobuf_wire::left_pad(
+                protobuf_wire::hex_to_bytes(s.parent_span_id), 8);
+            ref.ref_type = 0;
+            ps.references.push_back(std::move(ref));
+        }
+        auto st_ns = std::chrono::nanoseconds(s.start_time);
+        ps.start_time_seconds = static_cast<std::int64_t>(
+            std::chrono::duration_cast<std::chrono::seconds>(st_ns).count());
+        ps.start_time_nanos = static_cast<std::int32_t>(
+            (st_ns - std::chrono::seconds(ps.start_time_seconds)).count());
+        auto du_ns = std::chrono::nanoseconds(s.duration);
+        ps.duration_seconds = static_cast<std::int64_t>(
+            std::chrono::duration_cast<std::chrono::seconds>(du_ns).count());
+        ps.duration_nanos = static_cast<std::int32_t>(
+            (du_ns - std::chrono::seconds(ps.duration_seconds)).count());
+        for (const auto& [key, value] : s.tags) {
+            jaeger_proto::key_value kv;
+            kv.key = key;
+            kv.v_type = jaeger_proto::value_type::string_type;
+            kv.v_str = value;
+            ps.tags.push_back(std::move(kv));
+        }
+        b.spans.push_back(std::move(ps));
+    }
+    b.proc.service_name = service_name;
+    b.has_process = !service_name.empty();
+    return jaeger_proto::encode_batch(b);
+}
 
 /**
  * @struct zipkin_span_data
@@ -220,14 +318,78 @@ struct zipkin_span_data {
     }
 
     /**
-     * @brief Convert to Zipkin protobuf format (stub)
+     * @brief Convert this span to a Zipkin `Span` protobuf message.
+     *
+     * Field numbers follow `openzipkin/zipkin-api/zipkin.proto`. Trace IDs are
+     * expected to be 8 or 16 hex bytes; shorter inputs are zero-padded.
      */
     std::vector<uint8_t> to_protobuf() const {
-        // Protobuf serialization requires generated code
-        // Return empty for now - full implementation would use protobuf library
-        return {};
+        zipkin_proto::span out;
+        auto trace_bytes = protobuf_wire::hex_to_bytes(trace_id);
+        // Zipkin accepts 8 or 16 byte trace IDs; normalize the common
+        // shorter cases by padding to 8 bytes.
+        if (!trace_bytes.empty() && trace_bytes.size() != 16) {
+            out.trace_id = protobuf_wire::left_pad(trace_bytes, 8);
+        } else {
+            out.trace_id = trace_bytes;
+        }
+        out.id = protobuf_wire::left_pad(
+            protobuf_wire::hex_to_bytes(span_id), 8);
+        if (!parent_id.empty()) {
+            out.parent_id = protobuf_wire::left_pad(
+                protobuf_wire::hex_to_bytes(parent_id), 8);
+        }
+        out.kind = zipkin_proto::parse_kind(kind);
+        out.name = name;
+        out.timestamp = static_cast<std::uint64_t>(timestamp.count());
+        out.duration = static_cast<std::uint64_t>(duration.count());
+        out.local_endpoint.service_name = local_endpoint_service_name;
+        out.remote_endpoint.service_name = remote_endpoint_service_name;
+        out.shared = shared;
+        for (const auto& [key, value] : tags) {
+            out.tags.emplace_back(key, value);
+        }
+        return zipkin_proto::encode_span(out);
     }
 };
+
+/**
+ * @brief Encode a batch of Zipkin spans into a `ListOfSpans` protobuf message
+ *        suitable for POST /api/v2/spans with Content-Type
+ *        application/x-protobuf.
+ */
+inline std::vector<uint8_t> encode_zipkin_list_of_spans(
+    const std::vector<zipkin_span_data>& spans) {
+    zipkin_proto::list_of_spans list;
+    list.spans.reserve(spans.size());
+    for (const auto& s : spans) {
+        zipkin_proto::span ps;
+        auto trace_bytes = protobuf_wire::hex_to_bytes(s.trace_id);
+        if (!trace_bytes.empty() && trace_bytes.size() != 16) {
+            ps.trace_id = protobuf_wire::left_pad(trace_bytes, 8);
+        } else {
+            ps.trace_id = trace_bytes;
+        }
+        ps.id = protobuf_wire::left_pad(
+            protobuf_wire::hex_to_bytes(s.span_id), 8);
+        if (!s.parent_id.empty()) {
+            ps.parent_id = protobuf_wire::left_pad(
+                protobuf_wire::hex_to_bytes(s.parent_id), 8);
+        }
+        ps.kind = zipkin_proto::parse_kind(s.kind);
+        ps.name = s.name;
+        ps.timestamp = static_cast<std::uint64_t>(s.timestamp.count());
+        ps.duration = static_cast<std::uint64_t>(s.duration.count());
+        ps.local_endpoint.service_name = s.local_endpoint_service_name;
+        ps.remote_endpoint.service_name = s.remote_endpoint_service_name;
+        ps.shared = s.shared;
+        for (const auto& [key, value] : s.tags) {
+            ps.tags.emplace_back(key, value);
+        }
+        list.spans.push_back(std::move(ps));
+    }
+    return zipkin_proto::encode_list_of_spans(list);
+}
 
 /**
  * @class trace_exporter_interface
@@ -396,18 +558,23 @@ private:
     }
 
     common::VoidResult send_grpc_batch(const std::vector<jaeger_span_data>& spans) {
-        // gRPC would require a different transport mechanism
-        // For now, fall back to HTTP POST with protobuf
-        std::vector<uint8_t> payload;
-        for (const auto& span : spans) {
-            auto proto = span.to_protobuf();
-            payload.insert(payload.end(), proto.begin(), proto.end());
+        // Serialize as a Jaeger api_v2 `Batch` protobuf message. Real gRPC
+        // transport would additionally wrap this in a 5-byte gRPC length
+        // prefix and multiplex over HTTP/2; when a gRPC transport is
+        // available the raw `Batch` bytes below can be used as the message
+        // payload directly.
+        std::string resolved_service;
+        if (config_.service_name) {
+            resolved_service = *config_.service_name;
+        } else if (!spans.empty()) {
+            resolved_service = spans.front().service_name;
         }
+        auto payload = encode_jaeger_batch(spans, resolved_service);
 
         http_request request;
         request.url = config_.endpoint;
         request.method = "POST";
-        request.headers["Content-Type"] = "application/grpc+proto";
+        request.headers["Content-Type"] = "application/x-protobuf";
         for (const auto& [key, value] : config_.headers) {
             request.headers[key] = value;
         }
@@ -598,12 +765,9 @@ private:
     }
 
     common::VoidResult send_protobuf_batch(const std::vector<zipkin_span_data>& spans) {
-        // Build protobuf payload
-        std::vector<uint8_t> payload;
-        for (const auto& span : spans) {
-            auto proto = span.to_protobuf();
-            payload.insert(payload.end(), proto.begin(), proto.end());
-        }
+        // Serialize as a Zipkin `ListOfSpans` protobuf message. POST target
+        // accepts application/x-protobuf per Zipkin v2 API.
+        auto payload = encode_zipkin_list_of_spans(spans);
 
         http_request request;
         request.url = config_.endpoint + "/api/v2/spans";

--- a/tests/test_trace_exporters.cpp
+++ b/tests/test_trace_exporters.cpp
@@ -374,6 +374,212 @@ TEST_F(TraceExportersTest, LargeSpanBatch) {
 }
 
 // ==============================================================
+// Jaeger / Zipkin Protobuf Round-Trip Tests (Issue #670)
+// ==============================================================
+
+#include <kcenon/monitoring/exporters/internal/jaeger_proto.h>
+#include <kcenon/monitoring/exporters/internal/zipkin_proto.h>
+
+TEST(ProtobufWireTest, VarintRoundTrip) {
+    using namespace kcenon::monitoring::protobuf_wire;
+    const std::uint64_t values[] = {
+        0, 1, 127, 128, 255, 16383, 16384,
+        1000000000ULL, (std::uint64_t{1} << 63)
+    };
+    for (std::uint64_t v : values) {
+        std::vector<std::uint8_t> buf;
+        encode_varint(buf, v);
+        reader r(buf.data(), buf.size());
+        auto got = r.read_varint();
+        ASSERT_TRUE(got.has_value()) << "failed for value " << v;
+        EXPECT_EQ(*got, v);
+        EXPECT_TRUE(r.eof());
+    }
+}
+
+TEST(ProtobufWireTest, HexBytesRoundTrip) {
+    using namespace kcenon::monitoring::protobuf_wire;
+    const std::string hex = "0123456789abcdef";
+    auto bytes = hex_to_bytes(hex);
+    EXPECT_EQ(bytes.size(), 8u);
+    EXPECT_EQ(bytes_to_hex(bytes), hex);
+
+    // Invalid hex yields empty
+    EXPECT_TRUE(hex_to_bytes("xyz").empty());
+
+    // Left-padding to 16 bytes
+    auto padded = left_pad(bytes, 16);
+    EXPECT_EQ(padded.size(), 16u);
+    for (std::size_t i = 0; i < 8; ++i) EXPECT_EQ(padded[i], 0u);
+    for (std::size_t i = 0; i < 8; ++i) EXPECT_EQ(padded[8 + i], bytes[i]);
+}
+
+TEST_F(TraceExportersTest, JaegerSpanProtobufRoundTrip) {
+    trace_export_config config;
+    config.endpoint = "http://jaeger:14268";
+    config.format = trace_export_format::jaeger_grpc;
+    config.service_name = "test_service";
+
+    jaeger_exporter exporter(config);
+    auto jaeger_span = exporter.convert_span(test_spans_[0]);
+    auto wire = jaeger_span.to_protobuf();
+    ASSERT_FALSE(wire.empty());
+
+    kcenon::monitoring::jaeger_proto::span decoded;
+    ASSERT_TRUE(kcenon::monitoring::jaeger_proto::decode_span(
+        wire.data(), wire.size(), decoded));
+
+    // Core identifiers: 16-byte trace ID, 8-byte span ID
+    EXPECT_EQ(decoded.trace_id.size(), 16u);
+    EXPECT_EQ(decoded.span_id.size(), 8u);
+    EXPECT_EQ(decoded.operation_name, test_spans_[0].operation_name);
+
+    // Tags preserved (STRING ValueType).
+    bool found_method = false, found_url = false, found_kind = false;
+    for (const auto& kv : decoded.tags) {
+        if (kv.key == "http.method") {
+            EXPECT_EQ(kv.v_str, "GET");
+            EXPECT_EQ(static_cast<int>(kv.v_type), 0);
+            found_method = true;
+        } else if (kv.key == "http.url") {
+            EXPECT_EQ(kv.v_str, "/api/users");
+            found_url = true;
+        } else if (kv.key == "span.kind") {
+            EXPECT_EQ(kv.v_str, "server");
+            found_kind = true;
+        }
+    }
+    EXPECT_TRUE(found_method);
+    EXPECT_TRUE(found_url);
+    EXPECT_TRUE(found_kind);
+
+    // Process service name overridden from config.
+    EXPECT_EQ(decoded.proc.service_name, "test_service");
+}
+
+TEST_F(TraceExportersTest, JaegerSpanProtobufParentReference) {
+    trace_export_config config;
+    config.endpoint = "http://jaeger:14268";
+    config.format = trace_export_format::jaeger_grpc;
+
+    jaeger_exporter exporter(config);
+    // Second test span has parent_span_id set.
+    auto jaeger_span = exporter.convert_span(test_spans_[1]);
+    auto wire = jaeger_span.to_protobuf();
+
+    kcenon::monitoring::jaeger_proto::span decoded;
+    ASSERT_TRUE(kcenon::monitoring::jaeger_proto::decode_span(
+        wire.data(), wire.size(), decoded));
+
+    ASSERT_EQ(decoded.references.size(), 1u);
+    EXPECT_EQ(decoded.references[0].ref_type, 0);  // CHILD_OF
+    EXPECT_EQ(decoded.references[0].span_id.size(), 8u);
+}
+
+TEST_F(TraceExportersTest, JaegerBatchProtobufRoundTrip) {
+    trace_export_config config;
+    config.endpoint = "http://jaeger:14268";
+    config.format = trace_export_format::jaeger_grpc;
+    config.service_name = "batch_service";
+
+    jaeger_exporter exporter(config);
+    std::vector<jaeger_span_data> jaeger_spans;
+    for (const auto& s : test_spans_) {
+        jaeger_spans.push_back(exporter.convert_span(s));
+    }
+    auto wire = encode_jaeger_batch(jaeger_spans, "batch_service");
+    ASSERT_FALSE(wire.empty());
+
+    kcenon::monitoring::jaeger_proto::batch decoded;
+    ASSERT_TRUE(kcenon::monitoring::jaeger_proto::decode_batch(
+        wire.data(), wire.size(), decoded));
+    EXPECT_EQ(decoded.spans.size(), test_spans_.size());
+    EXPECT_TRUE(decoded.has_process);
+    EXPECT_EQ(decoded.proc.service_name, "batch_service");
+}
+
+TEST_F(TraceExportersTest, ZipkinSpanProtobufRoundTrip) {
+    trace_export_config config;
+    config.endpoint = "http://zipkin:9411";
+    config.format = trace_export_format::zipkin_protobuf;
+    config.service_name = "test_service";
+
+    zipkin_exporter exporter(config);
+    auto zipkin_span = exporter.convert_span(test_spans_[0]);
+    auto wire = zipkin_span.to_protobuf();
+    ASSERT_FALSE(wire.empty());
+
+    kcenon::monitoring::zipkin_proto::span decoded;
+    ASSERT_TRUE(kcenon::monitoring::zipkin_proto::decode_span(
+        wire.data(), wire.size(), decoded));
+
+    // Trace ID length: 8 or 16; span ID: 8 bytes.
+    EXPECT_TRUE(decoded.trace_id.size() == 8u || decoded.trace_id.size() == 16u);
+    EXPECT_EQ(decoded.id.size(), 8u);
+    EXPECT_EQ(decoded.name, "http_request");
+    EXPECT_EQ(decoded.kind, kcenon::monitoring::zipkin_proto::span_kind::server);
+    EXPECT_EQ(decoded.local_endpoint.service_name, "test_service");
+
+    // Tags preserved; span.kind excluded by convert_span.
+    bool found_method = false, found_url = false, found_kind = false;
+    for (const auto& [k, v] : decoded.tags) {
+        if (k == "http.method") { EXPECT_EQ(v, "GET"); found_method = true; }
+        if (k == "http.url") { EXPECT_EQ(v, "/api/users"); found_url = true; }
+        if (k == "span.kind") { found_kind = true; }
+    }
+    EXPECT_TRUE(found_method);
+    EXPECT_TRUE(found_url);
+    EXPECT_FALSE(found_kind);
+}
+
+TEST_F(TraceExportersTest, ZipkinSpanProtobufParent) {
+    trace_export_config config;
+    config.endpoint = "http://zipkin:9411";
+    config.format = trace_export_format::zipkin_protobuf;
+
+    zipkin_exporter exporter(config);
+    auto zipkin_span = exporter.convert_span(test_spans_[1]);
+    auto wire = zipkin_span.to_protobuf();
+
+    kcenon::monitoring::zipkin_proto::span decoded;
+    ASSERT_TRUE(kcenon::monitoring::zipkin_proto::decode_span(
+        wire.data(), wire.size(), decoded));
+    EXPECT_EQ(decoded.parent_id.size(), 8u);
+    EXPECT_EQ(decoded.kind, kcenon::monitoring::zipkin_proto::span_kind::client);
+}
+
+TEST_F(TraceExportersTest, ZipkinListOfSpansRoundTrip) {
+    trace_export_config config;
+    config.endpoint = "http://zipkin:9411";
+    config.format = trace_export_format::zipkin_protobuf;
+    config.service_name = "test_service";
+
+    zipkin_exporter exporter(config);
+    std::vector<zipkin_span_data> zipkin_spans;
+    for (const auto& s : test_spans_) {
+        zipkin_spans.push_back(exporter.convert_span(s));
+    }
+    auto wire = encode_zipkin_list_of_spans(zipkin_spans);
+    ASSERT_FALSE(wire.empty());
+
+    kcenon::monitoring::zipkin_proto::list_of_spans decoded;
+    ASSERT_TRUE(kcenon::monitoring::zipkin_proto::decode_list_of_spans(
+        wire.data(), wire.size(), decoded));
+    EXPECT_EQ(decoded.spans.size(), test_spans_.size());
+}
+
+TEST(ZipkinProtoTest, SpanKindParsing) {
+    using kcenon::monitoring::zipkin_proto::parse_kind;
+    using kcenon::monitoring::zipkin_proto::span_kind;
+    EXPECT_EQ(parse_kind("CLIENT"), span_kind::client);
+    EXPECT_EQ(parse_kind("server"), span_kind::server);
+    EXPECT_EQ(parse_kind("Producer"), span_kind::producer);
+    EXPECT_EQ(parse_kind("CONSUMER"), span_kind::consumer);
+    EXPECT_EQ(parse_kind(""), span_kind::unspecified);
+    EXPECT_EQ(parse_kind("INTERNAL"), span_kind::unspecified);
+}
+
+// ==============================================================
 // OTLP gRPC Exporter Tests
 // ==============================================================
 


### PR DESCRIPTION
## What

Replace the stub `to_protobuf()` implementations on `jaeger_span_data` and `zipkin_span_data` with a complete proto3 wire-format encoder/decoder targeting the published Jaeger `api_v2/model.proto` and Zipkin `zipkin.proto` schemas, and wire batch-level encoders (`Batch`, `ListOfSpans`) into the HTTP send path.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `include/kcenon/monitoring/exporters/internal/protobuf_wire.h` (new) - varint/fixed64/length-delimited primitives, tag encode/decode, hex helpers
- `include/kcenon/monitoring/exporters/internal/jaeger_proto.h` (new) - `Span`, `KeyValue`, `SpanRef`, `Process`, `Batch` encode/decode
- `include/kcenon/monitoring/exporters/internal/zipkin_proto.h` (new) - `Span`, `Endpoint`, `Annotation`, `ListOfSpans` encode/decode
- `include/kcenon/monitoring/exporters/trace_exporters.h` - wires `to_protobuf()` and batch-encoding; updates `send_grpc_batch` (Jaeger) and `send_protobuf_batch` (Zipkin)
- `tests/test_trace_exporters.cpp` - round-trip and parsing tests
- `CLAUDE.md` - narrows the known-gap note

## Why

Jaeger and Zipkin exporters previously stubbed the protobuf serialization path, so spans could not flow end-to-end to either backend. This PR delivers the wire-format portion of issue #670 so real collectors can accept our exported spans.

Closes #670

## How

### Encoder design
- Zero external dependencies (no protobuf runtime, no protoc). Header-only, `namespace kcenon::monitoring::protobuf_wire / jaeger_proto / zipkin_proto`.
- Field numbers match the canonical schemas verbatim:
  - Jaeger `Span`: trace_id=1, span_id=2, operation_name=3, references=4, flags=5, start_time=6, duration=7, tags=8, logs=9, process=10
  - Jaeger `KeyValue`: key=1, v_type=2, v_str=3, v_bool=4, v_int64=5, v_float64=6, v_binary=7
  - Zipkin `Span`: trace_id=1, parent_id=2, id=3, kind=4, name=5, timestamp=6 (fixed64), duration=7, local_endpoint=8, remote_endpoint=9, annotations=10, tags=11 (map<string,string>), debug=12, shared=13
- Trace IDs are zero-padded to 16 bytes and span IDs to 8 bytes per collector conventions.
- Zipkin tags encoded as the proto `map<string,string>` synthetic-message form (field 1 = key, field 2 = value).
- Decoders skip unknown/future fields safely.

### Format coverage
| Exporter | Wire format | Content-Type | Message |
|----------|-------------|--------------|---------|
| `jaeger_exporter` (`jaeger_thrift`) | JSON-over-HTTP (existing) | `application/x-thrift` | custom JSON |
| `jaeger_exporter` (`jaeger_grpc`) | **protobuf (new)** | `application/x-protobuf` | `Batch` |
| `zipkin_exporter` (`zipkin_json`) | JSON v2 (existing) | `application/json` | JSON array |
| `zipkin_exporter` (`zipkin_protobuf`) | **protobuf (new)** | `application/x-protobuf` | `ListOfSpans` |

### Testing
- Varint and hex-byte round-trip tests
- Single-span Jaeger round-trip: trace/span IDs correctly padded, operation name, tags (STRING `ValueType`), process service name override
- Jaeger parent-span `SpanRef` with `CHILD_OF` reference type
- Jaeger `Batch` round-trip with embedded `Process`
- Single-span Zipkin round-trip: kind enum, service name, tags (with `span.kind` excluded), timestamps
- Zipkin parent span bytes length
- Zipkin `ListOfSpans` round-trip
- Textual kind parsing (`CLIENT`, `server`, `Producer`, etc.)

### Breaking changes
None. Public types are unchanged; the Jaeger/Zipkin `to_protobuf()` methods previously returned `{}`, they now return valid wire bytes.

### Follow-up
Docker-backed integration tests against `jaegertracing/all-in-one` and `openzipkin/zipkin` containers (acceptance criteria bullets 1-2 of #670) depend on container runtimes in CI and are intentionally deferred. A follow-up issue is warranted for that milestone.

## Test Plan
- [ ] CI runs `monitoring_system_tests` and the new `ProtobufWireTest`, `ZipkinProtoTest`, `JaegerSpanProtobufRoundTrip`, `JaegerSpanProtobufParentReference`, `JaegerBatchProtobufRoundTrip`, `ZipkinSpanProtobufRoundTrip`, `ZipkinSpanProtobufParent`, `ZipkinListOfSpansRoundTrip` cases all pass
- [ ] Existing Jaeger/Zipkin conversion and exporter-behavior tests continue to pass