### PR TITLE
refactor(cmake): replace hardcoded source lists with structured globbing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,11 +519,13 @@ set(MONITORING_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(MONITORING_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # Collect source files
-file(GLOB_RECURSE MONITORING_HEADERS
+# CONFIGURE_DEPENDS makes CMake re-run the glob check at build time, so newly
+# added/removed files are picked up without manually re-running cmake.
+file(GLOB_RECURSE MONITORING_HEADERS CONFIGURE_DEPENDS
     ${MONITORING_INCLUDE_DIR}/kcenon/monitoring/*.h
 )
 
-file(GLOB_RECURSE MONITORING_SOURCES
+file(GLOB_RECURSE MONITORING_SOURCES CONFIGURE_DEPENDS
     ${MONITORING_SOURCE_DIR}/*.cpp
 )
 
@@ -558,12 +560,10 @@ target_link_libraries(monitoring_system PUBLIC
 #   kcenon.monitoring.adaptive - Adaptive monitoring
 ##################################################
 if(MONITORING_ENABLE_MODULES)
-    # Define module source files
-    set(MONITORING_MODULE_SOURCES
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/monitoring.cppm
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/core.cppm
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/collectors.cppm
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/adaptive.cppm
+    # Collect module source files
+    # CONFIGURE_DEPENDS picks up new .cppm files on reconfigure without manual list edits.
+    file(GLOB_RECURSE MONITORING_MODULE_SOURCES CONFIGURE_DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/*.cppm
     )
 
     # Create module library
@@ -719,12 +719,17 @@ endif()
 if(MONITORING_BUILD_HARDWARE_PLUGIN)
     message(STATUS "=== Building Hardware Monitoring Plugin ===")
 
+    # Hardware plugin sources (plugin wrapper only).
+    # Collector implementations (battery, power, temperature, gpu) are already
+    # compiled into monitoring_system (the main library) via the MONITORING_SOURCES
+    # GLOB; they are linked transitively through the PUBLIC dependency declared
+    # below, so the plugin library only needs to compile the plugin wrapper itself.
+    file(GLOB_RECURSE MONITORING_HARDWARE_PLUGIN_SOURCES CONFIGURE_DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/plugins/hardware/*.cpp
+    )
+
     add_library(monitoring_hardware_plugin STATIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/plugins/hardware/hardware_plugin.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/collectors/battery_collector.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/power_collector.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/temperature_collector.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/gpu_collector.cpp
+        ${MONITORING_HARDWARE_PLUGIN_SOURCES}
     )
 
     target_include_directories(monitoring_hardware_plugin
@@ -768,8 +773,15 @@ endif()
 if(MONITORING_BUILD_CONTAINER_PLUGIN)
     message(STATUS "=== Building Container Monitoring Plugin ===")
 
+    # Container plugin sources (plugin wrapper). Underlying collector
+    # implementations are compiled into monitoring_system via MONITORING_SOURCES
+    # and linked transitively through the PUBLIC dependency below.
+    file(GLOB_RECURSE MONITORING_CONTAINER_PLUGIN_SOURCES CONFIGURE_DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/plugins/container/*.cpp
+    )
+
     add_library(monitoring_container_plugin STATIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/plugins/container/container_plugin.cpp
+        ${MONITORING_CONTAINER_PLUGIN_SOURCES}
     )
 
     target_include_directories(monitoring_container_plugin
@@ -833,16 +845,14 @@ install(DIRECTORY include/kcenon/monitoring
     FILES_MATCHING PATTERN "*.h"
 )
 
+# Adapter headers are also collected via the install(DIRECTORY ...) call above,
+# but this explicit install is retained for the COMPONENT Development tag.
+file(GLOB MONITORING_ADAPTER_HEADERS CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/*.h
+)
+
 install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/common_adapters.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/thread_adapters.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/logger_adapters.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/common_to_monitoring_adapter.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/monitoring_to_common_adapter.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/thread_to_monitoring_adapter.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/logger_to_monitoring_adapter.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/monitor_adapter.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/monitoring/adapters/performance_monitor_adapter.h
+    ${MONITORING_ADAPTER_HEADERS}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon/monitoring/adapters
     COMPONENT Development
 )

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -17,14 +17,15 @@ endif()
 if(benchmark_FOUND OR BENCHMARK_FOUND)
     message(STATUS "Google Benchmark found. Building monitoring_system benchmarks...")
 
+    # Collect benchmark sources via glob.
+    # CONFIGURE_DEPENDS picks up newly-added benchmark files on reconfigure.
+    file(GLOB MONITORING_BENCHMARK_SOURCES CONFIGURE_DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+    )
+
     # Benchmark executable
     add_executable(monitoring_benchmarks
-        core_metrics_bench.cpp
-        metric_collection_bench.cpp
-        event_bus_bench.cpp
-        collector_overhead_bench.cpp
-        adaptive_monitor_bench.cpp
-        main_bench.cpp
+        ${MONITORING_BENCHMARK_SOURCES}
     )
 
     target_link_libraries(monitoring_benchmarks

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,162 +6,51 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/include
 )
 
-# Basic monitoring example
-add_executable(basic_monitoring_example
-    basic_monitoring_example.cpp
-)
-target_link_libraries(basic_monitoring_example
-    PRIVATE monitoring_system
-    Threads::Threads
+# Collect example sources via glob; each example is a single-file executable.
+# CONFIGURE_DEPENDS picks up newly-added examples on reconfigure.
+file(GLOB MONITORING_EXAMPLE_SOURCES CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
 )
 
-# Distributed tracing example
-add_executable(distributed_tracing_example
-    distributed_tracing_example.cpp
-)
-target_link_libraries(distributed_tracing_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
-
-# Health monitoring and reliability example
-add_executable(health_reliability_example
-    health_reliability_example.cpp
-)
-target_link_libraries(health_reliability_example
-    PRIVATE monitoring_system
-    Threads::Threads
+# Examples that are not currently built. Reasons vary (depend on internal
+# headers, proof-of-concept code, type mismatches awaiting fix). Keeping the
+# files in-tree but skipping their target registration mirrors the prior
+# behaviour after this glob conversion.
+list(REMOVE_ITEM MONITORING_EXAMPLE_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/bidirectional_di_example.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/event_bus_example.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/facade_adapter_poc.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/monitor_factory_pattern_example.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/plugin_collector_example.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/storage_example.cpp
 )
 
-# Result pattern example (existing)
-add_executable(result_pattern_example
-    result_pattern_example.cpp
+# Examples gated on common_system integration. Removed from the unconditional
+# list; re-added below inside the if() block.
+set(MONITORING_COMMON_SYSTEM_EXAMPLES
+    ${CMAKE_CURRENT_SOURCE_DIR}/logger_di_integration_example.cpp
 )
-target_link_libraries(result_pattern_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
+list(REMOVE_ITEM MONITORING_EXAMPLE_SOURCES ${MONITORING_COMMON_SYSTEM_EXAMPLES})
 
-# Custom metric types example (histogram, summary, timer)
-add_executable(custom_metric_types_example
-    custom_metric_types_example.cpp
-)
-target_link_libraries(custom_metric_types_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
-
-# Alert system examples
-add_executable(alert_pipeline_example
-    alert_pipeline_example.cpp
-)
-target_link_libraries(alert_pipeline_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
-
-add_executable(alert_triggers_example
-    alert_triggers_example.cpp
-)
-target_link_libraries(alert_triggers_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
-
-add_executable(alert_notifiers_example
-    alert_notifiers_example.cpp
-)
-target_link_libraries(alert_notifiers_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
-
-# Phase 2: Unified Collector Examples
-add_executable(system_collectors_example
-    system_collectors_example.cpp
-)
-target_link_libraries(system_collectors_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
-
-add_executable(platform_metrics_example
-    platform_metrics_example.cpp
-)
-target_link_libraries(platform_metrics_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
-
-add_executable(collector_factory_example
-    collector_factory_example.cpp
-)
-target_link_libraries(collector_factory_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
-
-# Phase 3: Advanced Integration Examples
-add_executable(otlp_export_example
-    otlp_export_example.cpp
-)
-target_link_libraries(otlp_export_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
-
-add_executable(time_series_storage_example
-    time_series_storage_example.cpp
-)
-target_link_libraries(time_series_storage_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
-
-add_executable(multi_service_tracing_example
-    multi_service_tracing_example.cpp
-)
-target_link_libraries(multi_service_tracing_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
-
-# Phase 4: Production Patterns Examples
-add_executable(production_monitoring_example
-    production_monitoring_example.cpp
-)
-target_link_libraries(production_monitoring_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
-
-add_executable(graceful_degradation_example
-    graceful_degradation_example.cpp
-)
-target_link_libraries(graceful_degradation_example
-    PRIVATE monitoring_system
-    Threads::Threads
-)
-
-# Phase 4 DI Pattern examples - available when common_system integration is enabled
-if(MONITORING_WITH_COMMON_SYSTEM OR MONITORING_USING_COMMON_INTERFACES)
-    # Logger DI Integration example
-    add_executable(logger_di_integration_example
-        logger_di_integration_example.cpp
-    )
-    target_link_libraries(logger_di_integration_example
+foreach(_example_src IN LISTS MONITORING_EXAMPLE_SOURCES)
+    get_filename_component(_example_name "${_example_src}" NAME_WE)
+    add_executable(${_example_name} ${_example_src})
+    target_link_libraries(${_example_name}
         PRIVATE monitoring_system
         Threads::Threads
     )
+endforeach()
 
-    # Monitor Factory Pattern example (TODO: Fix type mismatches)
-    # add_executable(monitor_factory_pattern_example
-    #     monitor_factory_pattern_example.cpp
-    # )
-    # target_link_libraries(monitor_factory_pattern_example
-    #     PRIVATE monitoring_system
-    #     Threads::Threads
-    # )
+# Phase 4 DI Pattern examples - available when common_system integration is enabled
+if(MONITORING_WITH_COMMON_SYSTEM OR MONITORING_USING_COMMON_INTERFACES)
+    foreach(_example_src IN LISTS MONITORING_COMMON_SYSTEM_EXAMPLES)
+        get_filename_component(_example_name "${_example_src}" NAME_WE)
+        add_executable(${_example_name} ${_example_src})
+        target_link_libraries(${_example_name}
+            PRIVATE monitoring_system
+            Threads::Threads
+        )
+    endforeach()
 
     message(STATUS "Phase 4 DI pattern examples enabled for monitoring_system")
 endif()

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -40,10 +40,11 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/sources
 )
 
-# Collect all test source files
-file(GLOB SCENARIO_TESTS scenarios/*.cpp)
-file(GLOB PERFORMANCE_TESTS performance/*.cpp)
-file(GLOB FAILURE_TESTS failures/*.cpp)
+# Collect all test source files.
+# CONFIGURE_DEPENDS makes CMake re-run the glob on build when files are added/removed.
+file(GLOB SCENARIO_TESTS CONFIGURE_DEPENDS scenarios/*.cpp)
+file(GLOB PERFORMANCE_TESTS CONFIGURE_DEPENDS performance/*.cpp)
+file(GLOB FAILURE_TESTS CONFIGURE_DEPENDS failures/*.cpp)
 
 # Create integration test executable
 add_executable(monitoring_integration_tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,128 +23,33 @@ if(NOT GTest_FOUND)
     message(STATUS "GTest fetched successfully")
 endif()
 
+# Collect test sources via glob, then exclude tests that have their own
+# executable target or are intentionally not part of the main test binary.
+# CONFIGURE_DEPENDS makes CMake re-run the glob when files are added/removed.
+file(GLOB MONITORING_TEST_SOURCES_ALL CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp
+)
+
+# Tests with their own add_executable() targets defined later in this file.
+list(REMOVE_ITEM MONITORING_TEST_SOURCES_ALL
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_interfaces_compile.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_container_plugin.cpp
+)
+
+# Tests intentionally excluded from monitoring_system_tests:
+#   - test_buffering_strategies.cpp: depends on internal headers under src/utils/
+#     that are not part of the public include path of the test target.
+#   - test_collector_registry.cpp: superseded by test_collector_registry_integration.cpp.
+#   - test_thread_context.cpp: superseded by test_thread_context_simple.cpp.
+list(REMOVE_ITEM MONITORING_TEST_SOURCES_ALL
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_buffering_strategies.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_collector_registry.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_thread_context.cpp
+)
+
 # Create test executable
 add_executable(monitoring_system_tests
-    # Core working tests (verified compiling and passing)
-    test_result_types.cpp
-    test_di_container.cpp
-    test_monitorable_interface.cpp
-    test_thread_context_simple.cpp
-    test_lock_free_collector.cpp
-    test_distributed_tracing.cpp
-    test_performance_monitoring.cpp
-    test_event_bus.cpp
-    test_trace_exporters.cpp
-    test_adapter_functionality.cpp
-    test_cross_system_integration.cpp
-
-    test_adaptive_monitoring.cpp
-    test_timer_metrics.cpp
-    test_service_registration.cpp
-
-    # Container metrics monitoring (Issue #228)
-    test_container_collector.cpp
-
-    # SMART disk health monitoring (Issue #227)
-    test_smart_collector.cpp
-
-    # Hardware temperature monitoring (Issue #215)
-    test_temperature_collector.cpp
-
-    # Process metrics monitoring (consolidated FD, inode, context switch - Issue #392)
-    test_process_metrics_collector.cpp
-
-    # Network metrics monitoring (consolidated from Issue #225, #226)
-    test_network_metrics_collector.cpp
-
-    # Interrupt statistics monitoring (Issue #223)
-    test_interrupt_collector.cpp
-
-    # Power consumption monitoring (Issue #216)
-    test_power_collector.cpp
-
-    # GPU metrics monitoring (Issue #221)
-    test_gpu_collector.cpp
-
-    # System resource monitoring (Issue #222)
-    test_system_resource_collector.cpp
-
-    # Security event monitoring (Issue #230)
-    test_security_collector.cpp
-
-    # Virtualization metrics monitoring (Issue #229)
-    test_vm_collector.cpp
-
-    # System uptime monitoring (Issue #217)
-    test_uptime_collector.cpp
-
-    # Battery status monitoring (Issue #218)
-    test_battery_collector.cpp
-
-    # Collector registry integration (Issue #446)
-    test_collector_registry_integration.cpp
-
-    # Load average history tracking (Issue #219)
-    test_time_series_buffer.cpp
-
-    # Platform metrics provider (Issue #295)
-    test_metrics_provider.cpp
-
-    # Platform metrics collector (Issue #393 - unified platform metrics using Strategy pattern)
-    test_platform_metrics_collector.cpp
-
-    # Metric exporters and OpenTelemetry adapter tests (Issue #320 - Phase 1)
-    test_metric_exporters.cpp
-    test_opentelemetry_adapter.cpp
-
-    # Storage backends test (Issue #326 - Phase 2, #343)
-    test_storage_backends.cpp
-
-    # Fault tolerance tests (Issue #329 - ARC-001 Phase 1)
-    test_fault_tolerance.cpp
-
-    # Error boundaries and graceful degradation tests (Issue #338)
-    test_error_boundaries.cpp
-
-    # Metric storage tests (Issue #339 - ring_buffer.h, metric_storage.h implemented)
-    test_metric_storage.cpp
-
-    # Resource management tests (Issue #341 - resource_manager.h implemented)
-    test_resource_management.cpp
-
-    # Health monitoring tests (Issue #330 - health_check, composite_health_check,
-    # health_dependency_graph, health_check_builder, global_health_monitor() implemented)
-    test_health_monitoring.cpp
-
-    # Data consistency tests (Issue #342 - data_consistency.h implemented)
-    test_data_consistency.cpp
-
-    # Stress performance tests (Issue #345 - headers fixed)
-    test_stress_performance.cpp
-
-    # Optimization tests (Issue #340 - optimization/ folder implemented)
-    test_optimization.cpp
-
-    # =========================================================================
-    # Phase 3 P2: Stream aggregation
-    test_stream_aggregation.cpp
-
-    # Integration E2E tests (Issue #346)
-    test_integration_e2e.cpp
-
-    # Metric factory tests (Issue #366)
-    test_metric_factory.cpp
-
-    # Statistics utilities tests (Issue #381)
-    test_statistics_utils.cpp
-
-    # Hot-path helper tests (Issue #387)
-    test_hot_path_helper.cpp
-
-    # Alert system tests (alert types, triggers, manager)
-    test_alert_types.cpp
-    test_alert_triggers.cpp
-    test_alert_manager.cpp
+    ${MONITORING_TEST_SOURCES_ALL}
 )
 
 # Interface compilation test (standalone executable with main())


### PR DESCRIPTION
## What

Replace every remaining hardcoded `.cpp`/`.h` source listing in the build with `file(GLOB ... CONFIGURE_DEPENDS)`, so CMake auto-detects new sources on reconfigure and the lists stop drifting from the filesystem.

### Change Type

- [x] Refactor (no functional changes)
- [ ] Feature
- [ ] Bugfix

### Affected Components

- `CMakeLists.txt` (root) - module sources, hardware plugin, container plugin, adapter header install
- `tests/CMakeLists.txt` - main test executable
- `examples/CMakeLists.txt` - all example targets
- `benchmarks/CMakeLists.txt` - benchmark executable
- `integration_tests/CMakeLists.txt` - existing globs gain `CONFIGURE_DEPENDS`

## Why

### Problem Solved

Hardcoded source lists drift silently when files move. The EPIC `#674` chose globbing as the desired outcome; this PR implements that decision for every remaining list, so adding a new `.cpp` to `src/` (or `tests/`, `examples/`, `benchmarks/`) is automatically picked up by the next reconfigure.

### Related Issues

- Closes #677
- Part of #674

## How

### Hardcoded blocks replaced (8)

| File | Block | Files in list | New form |
|------|-------|---------------|----------|
| `CMakeLists.txt` | `MONITORING_MODULE_SOURCES` | 4 `.cppm` | `file(GLOB_RECURSE ... src/modules/*.cppm)` |
| `CMakeLists.txt` | `monitoring_hardware_plugin` sources | 5 `.cpp` | `file(GLOB_RECURSE ... src/plugins/hardware/*.cpp)` |
| `CMakeLists.txt` | `monitoring_container_plugin` sources | 1 `.cpp` | `file(GLOB_RECURSE ... src/plugins/container/*.cpp)` |
| `CMakeLists.txt` | `install(FILES adapters/...h)` | 9 `.h` | `file(GLOB ... adapters/*.h)` |
| `tests/CMakeLists.txt` | `monitoring_system_tests` | ~46 `.cpp` | `file(GLOB ... test_*.cpp)` + `list(REMOVE_ITEM ...)` |
| `examples/CMakeLists.txt` | 17 single-file `add_executable` blocks | 17 `.cpp` | foreach over glob result |
| `benchmarks/CMakeLists.txt` | `monitoring_benchmarks` | 6 `.cpp` | `file(GLOB ... *.cpp)` |
| `integration_tests/CMakeLists.txt` | already had `SCENARIO/PERFORMANCE/FAILURE_TESTS` GLOBs | n/a | `CONFIGURE_DEPENDS` added |

### GLOBs that gained `CONFIGURE_DEPENDS` (5)

- `MONITORING_HEADERS`, `MONITORING_SOURCES` in `CMakeLists.txt` (the existing main-library globs were missing the flag)
- `SCENARIO_TESTS`, `PERFORMANCE_TESTS`, `FAILURE_TESTS` in `integration_tests/CMakeLists.txt`

All new globs in this PR are created with `CONFIGURE_DEPENDS` from the start.

### Behaviour-preserving notes

- **Hardware / container plugins.** The previous code added the plugin's collector implementations (`battery_collector.cpp`, `power_collector.cpp`, `temperature_collector.cpp`, `gpu_collector.cpp`, plus the container plugin's collectors) directly to the plugin library, *and* those same files are also compiled into the main `monitoring_system` library by the `MONITORING_SOURCES` glob. The plugin libraries declare `PUBLIC` dependency on `monitoring_system`, so consumers always see one definition through the main library; the duplicate compilation in the plugin static archive was redundant. The new globs scope each plugin to `src/plugins/<name>/*.cpp` only - the collector implementations are still pulled in for any consumer through the existing `PUBLIC` link to `monitoring_system`. No public API or symbol changes.
- **Excluded test files.** `test_buffering_strategies.cpp` (depends on private headers under `src/utils/`), `test_collector_registry.cpp` (superseded by `test_collector_registry_integration.cpp`), and `test_thread_context.cpp` (superseded by `test_thread_context_simple.cpp`) were intentionally not part of the prior hardcoded list. They are now excluded by name via `list(REMOVE_ITEM ...)`, with comments documenting why. Same for `test_interfaces_compile.cpp` and `test_container_plugin.cpp`, which have their own executable targets.
- **Excluded examples.** `bidirectional_di_example`, `event_bus_example`, `facade_adapter_poc`, `monitor_factory_pattern_example`, `plugin_collector_example`, and `storage_example` were not previously registered (PoCs, WIP TODOs, or depend on internal APIs). They are excluded by name from the new example glob to keep behaviour identical.

### Out-of-scope (left untouched)

- Dependency-discovery fallback blocks for `thread_system` / `logger_system` / `network_system` / `common_system` (sibling subdirectory + `find_package` + env-var ladder). These are about *where a dependency lives*, not about *which `.cpp` files it compiles*, and are load-bearing for CI.
- Tier 2 install fallback at the `MONITORING_CAN_INSTALL` branch.
- Test directory reorganisation (#679).
- CMake decomposition into `cmake/<area>.cmake` modules (#678).

## Where

| File | Lines (before -> after) |
|------|-------------------------|
| `CMakeLists.txt` | 939 -> 949 |
| `tests/CMakeLists.txt` | 216 -> 120 |
| `examples/CMakeLists.txt` | 167 -> 55 |
| `benchmarks/CMakeLists.txt` | 90 -> 90 |
| `integration_tests/CMakeLists.txt` | 139 -> 139 |

Net diff: 5 files, 110 insertions, 304 deletions.

## Verification

### Local

Local environment in this sandbox does not have CMake/GCC/Clang installed, so build verification relies on CI (same approach used for sibling PRs #680 and #681).

### "Touch a file -> CMake picks it up" criterion

This PR adds `CONFIGURE_DEPENDS` to every glob (including the previously-existing `MONITORING_HEADERS` / `MONITORING_SOURCES` globs which lacked it). With `CONFIGURE_DEPENDS`, CMake re-runs the glob expression on every build invocation; if the result differs from the cached value, CMake re-configures before building. This is the canonical mechanism for the criterion stated in #677. Verification of the runtime behaviour is delegated to CI (which reconfigures and builds from scratch every run, exercising the globs against the current filesystem state).

### Acceptance criteria

- [x] Zero hardcoded `.cpp` / `.h` listings in `CMakeLists.txt` and any module under `cmake/` (the only remaining `.h` references are in dependency-discovery fallbacks, which are out of scope per the EPIC body)
- [x] All globs use `CONFIGURE_DEPENDS`
- [ ] Build green, ctest passes (depends on CI)
- [x] Adding a new source file under `src/<feature>/` and reconfiguring picks it up automatically (mechanism: `CONFIGURE_DEPENDS`)