### PR TITLE
chore(includes): migrate to canonical kcenon/thread/* paths

### DIFF
--- a/integration_tests/vcpkg_consumer/main.cpp
+++ b/integration_tests/vcpkg_consumer/main.cpp
@@ -22,7 +22,7 @@
 
 // Tier 1: thread_system (optional)
 #ifdef HAS_THREAD_SYSTEM
-#include <thread_system/utilities/formatter.h>
+#include <kcenon/thread/utils/formatter.h>
 #endif
 
 // Tier 1: container_system (optional)


### PR DESCRIPTION
## What

Migrate the legacy include path in the vcpkg consumer integration test to the canonical `<kcenon/thread/...>` layout.

| File | Old | New |
|------|-----|-----|
| `integration_tests/vcpkg_consumer/main.cpp:25` | `#include <thread_system/utilities/formatter.h>` | `#include <kcenon/thread/utils/formatter.h>` |

## Why

`thread_system` EPIC kcenon/thread_system#683 standardized the public include layout under `<kcenon/thread/...>`. The legacy install path `<thread_system/...>` is preserved as a forwarding header marked `[[deprecated]]` for backward compatibility, and is scheduled for removal in the next minor release of `thread_system`. Static audit found this single legacy include in this repository.

## How

- Single-line edit at `integration_tests/vcpkg_consumer/main.cpp:25`
- Repository-wide grep verified no other `#include <thread_system/...>` occurrences remain

## Test Plan

- The vcpkg consumer integration test is exercised by `validate-vcpkg-chain.yml` against the vcpkg-installed `kcenon-thread-system` port. Local toolchain (cmake/g++/vcpkg) was not available; verification is delegated to CI.
- Acceptance criteria from #685:
  - [x] No `#include` statements use the legacy `<thread_system/...>` path
  - [ ] vcpkg consumer integration test still finds and links `kcenon-thread-system` (CI verifies)
  - [ ] Build emits zero deprecation warnings from `thread_system` forwarding headers (CI verifies)

Closes #685