### PR TITLE
chore(release): verify SHA512 against actual archive (#687)

### DIFF
--- a/.github/workflows/on-release-sync-registry.yml
+++ b/.github/workflows/on-release-sync-registry.yml
@@ -5,7 +5,57 @@ on:
     types: [published]
 
 jobs:
+  verify-archive:
+    name: Verify release archive SHA512
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify SHA512 against actual GitHub archive
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Independent SHA512 verification against the released archive.
+          # The reusable sync workflow at kcenon/common_system already performs
+          # this check internally (see kcenon/common_system#675, PR #676), but
+          # repeating it here on the caller side guards against drift if the
+          # reusable workflow changes or is repointed in the future.
+          # Reference: kcenon/monitoring_system#687, EPIC kcenon/common_system#674.
+          set -euo pipefail
+          ARCHIVE_URL="https://github.com/${REPO}/archive/refs/tags/${TAG}.tar.gz"
+          VERIFY_FILE="$(mktemp)"
+
+          echo "Fetching ${ARCHIVE_URL} for SHA512 verification..."
+          # Download to a file (not piped into sha512sum) so a fetch failure
+          # cannot silently produce the empty-input hash cf83e1357eefb8bdf...
+          if ! curl -fsSL --retry 3 --retry-delay 2 -o "${VERIFY_FILE}" "${ARCHIVE_URL}"; then
+            echo "::error::Failed to download release archive: ${ARCHIVE_URL}"
+            rm -f "${VERIFY_FILE}"
+            exit 1
+          fi
+
+          ARCHIVE_SIZE=$(stat -c %s "${VERIFY_FILE}" 2>/dev/null || stat -f %z "${VERIFY_FILE}")
+          if [ "${ARCHIVE_SIZE}" -lt 1024 ]; then
+            echo "::error::Downloaded archive is suspiciously small (${ARCHIVE_SIZE} bytes)"
+            rm -f "${VERIFY_FILE}"
+            exit 1
+          fi
+
+          ACTUAL_SHA=$(sha512sum "${VERIFY_FILE}" | awk '{print $1}')
+          rm -f "${VERIFY_FILE}"
+
+          # Empty-input SHA-512 sentinel guard.
+          EMPTY_SHA="cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+          if [ "${ACTUAL_SHA}" = "${EMPTY_SHA}" ]; then
+            echo "::error::Computed SHA512 matches the empty-input constant; download likely failed."
+            exit 1
+          fi
+
+          echo "SHA512 of ${ARCHIVE_URL}:"
+          echo "  ${ACTUAL_SHA}"
+          echo "Archive size: ${ARCHIVE_SIZE} bytes"
+
   sync:
+    needs: verify-archive
     uses: kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml@main
     with:
       port-name: kcenon-monitoring-system


### PR DESCRIPTION
Closes #687

Part of kcenon/common_system#674.

## What

Adds an independent SHA512 verification step to `.github/workflows/on-release-sync-registry.yml`. The new `verify-archive` job re-downloads the GitHub release archive from `https://github.com/kcenon/monitoring_system/archive/refs/tags/<tag>.tar.gz`, recomputes its SHA512, and runs before the existing `sync` job that calls the reusable workflow at `kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml@main`.

## Why

Detected via [microsoft/vcpkg#51511](https://github.com/microsoft/vcpkg/issues/51511) and [kcenon/vcpkg-registry#87](https://github.com/kcenon/vcpkg-registry/issues/87) - every kcenon port shipped a mismatched SHA512 because release workflows never compared the computed value against the actual archive. Cold-cache vcpkg consumers (new CI runners, fresh users) hit 100% install failure when the SHA in `vcpkg-registry/ports/kcenon-monitoring-system/portfile.cmake` does not match the bytes the consumer actually fetches.

The reusable sync workflow at `kcenon/common_system` was already hardened in [kcenon/common_system PR #676](https://github.com/kcenon/common_system/pull/676), so `monitoring_system` inherits that check via the `uses:` reference. Adding a caller-side verification job in this repo provides defense-in-depth: if the reusable workflow is ever repointed, refactored, or its check is removed, this repo's release pipeline still fails fast on a bad archive.

## Where

| File | Change |
|------|--------|
| `.github/workflows/on-release-sync-registry.yml` | New `verify-archive` job added before `sync`; `sync` now declares `needs: verify-archive` |

### Audit summary (other workflows considered)

| Workflow | Touches portfile SHA? | Action |
|----------|----------------------|--------|
| `on-release-sync-registry.yml` | Calls reusable sync (which writes SHA512) | **Hardened (this PR)** |
| `ci.yml` | No (build/test only) | No change |
| `sanitizers.yml` | No (build/test only) | No change |
| `benchmarks.yml` | No (perf measurement) | No change |
| `coverage.yml` | No (coverage upload) | No change |
| `cve-scan.yml`, `dependency-security-scan.yml`, `osv-scanner.yml`, `sbom.yml` | Hash dependencies, not portfile SHA | Out of scope |
| `static-analysis.yml`, `integration-tests.yml`, `doc-audit.yml`, `build-Doxygen.yaml` | No SHA writes | No change |
| `validate-vcpkg-chain.yml` | Validates vcpkg consumer build, does not write portfile SHA | No change |

Only `on-release-sync-registry.yml` participates in writing SHA512 to portfiles, so a single inline verification job in that workflow is appropriate. No composite action extraction is needed.

## How

The new `verify-archive` job runs on `ubuntu-latest` and:

1. Downloads the release archive to a temp file via `curl -fsSL --retry 3 --retry-delay 2 -o <file> <url>` (file-based, never piped into `sha512sum`).
2. Verifies the downloaded file is at least 1024 bytes.
3. Computes `sha512sum` of the file.
4. Refuses to proceed if the digest equals the well-known empty-input SHA512 (`cf83e1357eefb8bdf...`), which would indicate a silent fetch failure.
5. The `sync` job declares `needs: verify-archive`, so a failed verification short-circuits the registry update before any portfile commit.

The reusable sync workflow at `kcenon/common_system` performs the same comparison server-side using the SHA it just wrote to the portfile, providing two-layer protection.

## Test Plan

### How a reviewer can validate the new job fires

1. After merge, cut a release tag (`v0.x.y`). The `Sync Registry on Release` workflow triggers automatically.
2. Inspect the run log for the new `Verify release archive SHA512` job. On a healthy release, it prints:
   ```
   Fetching https://github.com/kcenon/monitoring_system/archive/refs/tags/v0.x.y.tar.gz for SHA512 verification...
   SHA512 of https://github.com/kcenon/monitoring_system/archive/refs/tags/v0.x.y.tar.gz:
     <128-char hex digest>
   Archive size: <N> bytes
   ```
3. The `sync` job then runs only if `verify-archive` succeeded.

### Negative-path verification

To confirm the guard fires on a bad archive URL, a maintainer can temporarily replace the `TAG` env value in the workflow with a non-existent tag on a feature branch and trigger the workflow against a synthetic release - the `verify-archive` job will fail with `::error::Failed to download release archive`, and the `sync` job will be skipped.

## Acceptance Criteria

- [x] Audit identifies all release workflow files in this repo that compute or commit SHA512 (`on-release-sync-registry.yml` only)
- [x] That workflow includes a "verify SHA against actual archive" gate that runs before the registry sync commits the portfile
- [x] File-based hashing is used (no `curl | sha512sum`) so 404s cannot produce the empty-input sentinel hash
- [x] Audit summary documents why the other 14 workflows do not need changes

## References

- Parent EPIC: kcenon/common_system#674
- Reference implementation: kcenon/common_system#675 / PR kcenon/common_system#676
- Cross-port audit: kcenon/vcpkg-registry#87
- Original finding: microsoft/vcpkg#51511
