### PR TITLE
docs(audit): classify collector/plugin stubs and support levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,11 @@ factory.register_collector("my_collector", []() {
 
 📖 [Factory API Reference →](docs/API_REFERENCE.md#metric-factory)
 
+> **Support status**: Not every collector, plugin, or exporter is production-ready.
+> Before integrating a component, check the code-verified classification in
+> [Component Support Status](docs/SUPPORT_STATUS.md) — it distinguishes
+> `production`, `experimental`, and `test-only` components.
+
 ---
 
 ## Architecture Overview

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ category: "GUID"
 > **SSOT**: This file is the single source of truth for the documentation index
 > of **monitoring_system**.
 
-Total documents: **81**
+Total documents: **82**
 
 ## Document Index
 
@@ -86,6 +86,7 @@ Total documents: **81**
 | 65 | MON-QUAL-001 | Monitoring System - 프로덕션 품질 메트릭 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | 66 | MON-QUAL-002 | Monitoring System - Production Quality Metrics | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
 | 67 | MON-QUAL-005 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| 82 | MON-QUAL-006 | Component Support Status | [SUPPORT_STATUS.md](./SUPPORT_STATUS.md) | Released |
 | 68 | MON-QUAL-003 | Testing Guide | [TESTING_GUIDE.md](./contributing/TESTING_GUIDE.md) | Released |
 | 69 | MON-QUAL-004 | Reliability Patterns Usage Guide | [RELIABILITY_PATTERNS.md](./guides/RELIABILITY_PATTERNS.md) | Released |
 | 70 | MON-SECU-001 | 보안 정책 | [SECURITY.kr.md](./guides/SECURITY.kr.md) | Released |
@@ -202,13 +203,14 @@ Total documents: **81**
 | MON-INTR-003 | OpenTelemetry Collector 사이드카 패턴 | [OTEL_COLLECTOR_SIDECAR.kr.md](./guides/OTEL_COLLECTOR_SIDECAR.kr.md) | Released |
 | MON-INTR-004 | OpenTelemetry Collector Sidecar Pattern | [OTEL_COLLECTOR_SIDECAR.md](./guides/OTEL_COLLECTOR_SIDECAR.md) | Released |
 
-### Quality (5)
+### Quality (6)
 
 | doc_id | Topic | Document | Status |
 |--------|-------|----------|--------|
 | MON-QUAL-001 | Monitoring System - 프로덕션 품질 메트릭 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | MON-QUAL-002 | Monitoring System - Production Quality Metrics | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
 | MON-QUAL-005 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| MON-QUAL-006 | Component Support Status | [SUPPORT_STATUS.md](./SUPPORT_STATUS.md) | Released |
 | MON-QUAL-003 | Testing Guide | [TESTING_GUIDE.md](./contributing/TESTING_GUIDE.md) | Released |
 | MON-QUAL-004 | Reliability Patterns Usage Guide | [RELIABILITY_PATTERNS.md](./guides/RELIABILITY_PATTERNS.md) | Released |
 

--- a/docs/SUPPORT_STATUS.md
+++ b/docs/SUPPORT_STATUS.md
@@ -1,0 +1,168 @@
+---
+doc_id: "MON-QUAL-006"
+doc_title: "Monitoring System - Component Support Status"
+doc_version: "1.0.0"
+doc_date: "2026-05-21"
+doc_status: "Released"
+project: "monitoring_system"
+category: "QUAL"
+---
+
+# Monitoring System — Component Support Status
+
+> **SSOT**: This document is the single source of truth for the **support level**
+> of every collector, plugin, and exporter in monitoring_system. It is the audit
+> deliverable for [issue #689](https://github.com/kcenon/monitoring_system/issues/689)
+> (part of [common_system#684](https://github.com/kcenon/common_system/issues/684)).
+
+## Purpose
+
+The README describes monitoring_system as a modern observability platform with
+collectors, tracing, alerting, plugins, and exporters. Downstream consumers need
+to distinguish components that are production-ready from examples, placeholders,
+and not-yet-implemented headers. This table classifies each component by a
+**code-verified** support level so feature claims are auditable.
+
+## Support Levels
+
+| Level | Meaning |
+|-------|---------|
+| `production` | Header + source implementation present, exercised by tests, safe to integrate. |
+| `experimental` | Public API exists and works, but behaviour is environment-dependent (e.g. requires an optional dependency; falls back to a non-transmitting stub otherwise). Use with awareness. |
+| `test-only` | Declared in headers but **no implementation** is compiled or linked. Present only as an interface sketch; not usable at runtime. |
+| `remove` | Recommended for removal. *(None at this time.)* |
+
+## Audit Method
+
+Classification is based on the **code as SSOT**, not on documentation claims:
+
+1. Marker sweep — `grep -rni -E "TODO|FIXME|HACK|stub|placeholder|not implemented" include src tests benchmarks`.
+2. Implementation check — whether a `.cpp` (or inline header definition) actually
+   defines the component's member functions, and whether the build (`cmake/sources.cmake`,
+   `file(GLOB_RECURSE ... src/*.cpp)`) links it.
+3. Test check — whether a dedicated test exists under `tests/`.
+4. Factory check — whether `include/kcenon/monitoring/factory/builtin_collectors.h`
+   registers the component.
+
+Most markers found in `tests/` (69) and `benchmarks/` (7) are harmless test
+scaffolding (mock objects, fixture comments) and do **not** indicate production gaps.
+The marker counts that matter are in `include/` and `src/`.
+
+## Collectors
+
+`include/kcenon/monitoring/collectors/` — 17 collector headers + `collector_base.h`.
+
+| Component | Kind | Support | Evidence | Notes |
+|-----------|------|---------|----------|-------|
+| `collector_base` | collector | `production` | CRTP base, header-only template; consumed by collectors. | Infrastructure, not a runtime collector. |
+| `battery_collector` | collector | `production` | `src/collectors/battery_collector.cpp`; `tests/collectors/test_battery_collector.cpp`; registered in `builtin_collectors.h`. | |
+| `container_collector` | collector | `production` | `src/collectors/container_collector.cpp`; test present; registered. | Linux cgroup v1/v2 with graceful degradation. |
+| `gpu_collector` | collector | `production` | `src/platform/gpu_collector.cpp`; test present. | Windows path is a documented platform stub (no GPU data on Windows). |
+| `interrupt_collector` | collector | `production` | `src/collectors/interrupt_collector.cpp`; test present; registered. | Windows path not implemented (documented platform limitation). |
+| `network_metrics_collector` | collector | `production` | `src/collectors/network_metrics_collector.cpp`; test present; registered. | Windows path is a documented platform stub. |
+| `platform_metrics_collector` | collector | `production` | `src/collectors/platform_metrics_collector.cpp`; test present; registered. | |
+| `power_collector` | collector | `production` | `src/platform/power_collector.cpp`; test present. | |
+| `process_metrics_collector` | collector | `production` | `src/collectors/process_metrics_collector.cpp`; test present; registered. | |
+| `security_collector` | collector | `production` | `src/platform/security_collector.cpp`; test present; registered. | Windows path is a documented platform stub. |
+| `smart_collector` | collector | `production` | `src/platform/smart_metrics.cpp` defines `smart_collector::*`; test present; registered. | Uses `smartctl`; degrades gracefully when unavailable. |
+| `system_resource_collector` | collector | `production` | `src/collectors/system_resource_collector.cpp`; test present; registered. | Windows PDH path has documented safe-stub branches. |
+| `temperature_collector` | collector | `production` | `src/platform/temperature_collector.cpp`; test present. | |
+| `uptime_collector` | collector | `production` | `src/collectors/uptime_collector.cpp`; test present; registered. | |
+| `vm_collector` | collector | `production` | `src/collectors/vm_collector.cpp`; test present; registered. | Windows path stubbed; CPU-steal is a documented placeholder. |
+| `logger_system_collector` | collector | `test-only` | Header `logger_system_collector.h` declares ctor/`collect()`/`initialize()`/`get_statistics()`/`get_metric_types()`, but **no `.cpp` defines them**, no header inline body, no file includes it, no test, not in `builtin_collectors.h`. | Interface sketch only. Not compiled into the library. See follow-up issue. |
+| `thread_system_collector` | collector | `test-only` | Header declares `collect()` etc.; **no implementation**, no test, not registered. | Interface sketch only. See follow-up issue. |
+| `plugin_metric_collector` | collector | `test-only` | Header declares `force_collect()` and management API; **no implementation**, no test, not registered. | Interface sketch only. See follow-up issue. |
+
+### Collector summary
+
+- `production`: 15 (`collector_base` + 14 runtime collectors)
+- `test-only`: 3 (`logger_system_collector`, `thread_system_collector`, `plugin_metric_collector`)
+- `experimental`: 0
+- `remove`: 0
+
+Platform-specific stub branches (Windows GPU/interrupt/PDH, VM steal placeholder)
+inside otherwise-production collectors are **documented platform limitations**, not
+support-level downgrades — the collectors compile, link, are tested, and degrade
+gracefully.
+
+## Plugins
+
+`include/kcenon/monitoring/plugins/` and `src/plugins/`.
+
+| Component | Kind | Support | Evidence | Notes |
+|-----------|------|---------|----------|-------|
+| `collector_plugin` | plugin interface | `production` | `collector_plugin.h` — abstract interface, implemented by built-in collectors. | |
+| `plugin_api` | plugin interface | `production` | `plugin_api.h` — `DECLARE_MONITORING_PLUGIN` macro and C ABI declarations. | |
+| `collector_registry` | plugin infra | `production` | `src/plugins/collector_registry.cpp` (349 lines); `tests/plugins/test_collector_registry*.cpp`. | |
+| `plugin_loader` | plugin infra | `production` | `src/plugins/plugin_loader.cpp` (335 lines) — real `dlopen`/`LoadLibraryA` dynamic loading. | |
+| `container_plugin` | plugin | `production` | `src/plugins/container/container_plugin.cpp` (304 lines); `tests/plugins/test_container_plugin.cpp`. | |
+| `hardware_plugin` | plugin | `production` | `src/plugins/hardware/hardware_plugin.cpp` (298 lines). | |
+
+### Plugin summary
+
+- `production`: 6
+- No stub/placeholder markers found in `src/plugins/`.
+
+## Exporters
+
+`include/kcenon/monitoring/exporters/` — header-only (no `src/` directory; classes are inline in headers).
+
+| Component | Kind | Support | Evidence | Notes |
+|-----------|------|---------|----------|-------|
+| `metric_exporters` | exporter | `production` | `prometheus_exporter`, `statsd_exporter`, `otlp_metrics_exporter` fully defined; `tests/integration/test_metric_exporters.cpp`. | StatsD UDP send path is `// simulated` when no transport is wired — see note below. |
+| `trace_exporters` | exporter | `production` | Fully defined; `tests/integration/test_trace_exporters.cpp`. | |
+| `opentelemetry_adapter` | exporter | `production` | Fully defined; `tests/integration/test_opentelemetry_adapter.cpp`. | |
+| `http_transport` | transport | `experimental` | `http_transport.h` ships `stub_http_transport` (returns an error in stub mode) and a real path behind `MONITORING_HAS_NETWORK_SYSTEM`. | Without `network_system`, the factory falls back to the non-transmitting stub. Mark integrations accordingly. |
+| `udp_transport` | transport | `experimental` | `udp_transport.h` ships `stub_udp_transport` (testing), `simple`, and a real path. | Stub is the fallback when no real backend is configured. |
+| `grpc_transport` | transport | `experimental` | `grpc_transport.h` ships `stub_grpc_transport` (testing) and a real `grpc::GenericStub` path. | `create_grpc_transport()` falls back to the stub when gRPC is unavailable. |
+| `otlp_grpc_exporter` | exporter | `experimental` | `otlp_grpc_exporter.h` fully defined, but `export_spans()` runs over a `grpc_transport` that is the stub unless a real gRPC backend is present. | Functional only when paired with a real (non-stub) gRPC transport. |
+
+### Exporter summary
+
+- `production`: 3 (`metric_exporters`, `trace_exporters`, `opentelemetry_adapter`)
+- `experimental`: 4 (`http_transport`, `udp_transport`, `grpc_transport`, `otlp_grpc_exporter`)
+
+The `stub_*_transport` classes are intentional **testing seams** named `stub` — they
+are part of the supported transport abstraction, not unfinished work. The
+`experimental` label reflects that real network transmission depends on the optional
+`network_system`/gRPC backends being present.
+
+## Storage Backends (related)
+
+`include/kcenon/monitoring/storage/storage_backends.h` — outside the issue scope but
+flagged during the audit for completeness.
+
+| Component | Support | Notes |
+|-----------|---------|-------|
+| `memory_storage_backend` | `production` | In-memory snapshot store, fully functional. |
+| `file_storage_backend` | `experimental` | `flush()` is a stub (`// actual file I/O would go here`); data is held in memory only. |
+| `database_storage_backend` | `experimental` | Header comment marks it a stub implementation. |
+| `cloud_storage_backend` | `experimental` | Header comment marks it a stub implementation. |
+
+Storage backend gaps are tracked separately; this table records them so the audit is complete.
+
+## Marker Accounting
+
+`grep -rni -E "TODO|FIXME|HACK|stub|placeholder|not implemented"` results:
+
+| Path | Count | Disposition |
+|------|-------|-------------|
+| `include/` | 51 | All accounted for: `stub_*_transport` classes (intentional testing seams), documented Windows platform stubs in collectors, storage backend stub comments. See tables above. |
+| `src/` | 12 | Documented platform limitations (Windows GPU/interrupt/PDH), VM steal placeholder, Docker stub on non-Linux — all graceful-degradation paths in production collectors. |
+| `tests/` | 69 | Harmless test scaffolding (mocks, fixtures). Not production gaps. |
+| `benchmarks/` | 7 | Harmless benchmark scaffolding. Not production gaps. |
+
+No marker indicates an undocumented production gap. The only true unimplemented
+components are the three `test-only` collectors, which carry follow-up issues.
+
+## Follow-up Issues
+
+Components shipped as if production but backed by no implementation:
+
+- `logger_system_collector`, `thread_system_collector`, `plugin_metric_collector` —
+  tracked by [issue #690](https://github.com/kcenon/monitoring_system/issues/690)
+  (implement or remove the three `test-only` stub collectors).
+
+---
+
+*Audit deliverable for issue [#689](https://github.com/kcenon/monitoring_system/issues/689).*

--- a/docs/plugin_api_reference.md
+++ b/docs/plugin_api_reference.md
@@ -12,6 +12,13 @@ category: "API"
 
 > **SSOT**: This document is the single source of truth for **Plugin API Reference**.
 
+> **Support status**: The plugin infrastructure (`collector_plugin`, `plugin_api`,
+> `collector_registry`, `plugin_loader`, `container_plugin`, `hardware_plugin`) is
+> `production`. Note that the `logger_system_collector`, `thread_system_collector`,
+> and `plugin_metric_collector` headers under `collectors/`/`plugins/` are
+> `test-only` interface sketches with no compiled implementation — do not treat
+> them as usable plugins. See [Component Support Status](./SUPPORT_STATUS.md).
+
 Complete reference for the collector plugin API.
 
 ## Table of Contents

--- a/include/kcenon/monitoring/collectors/logger_system_collector.h
+++ b/include/kcenon/monitoring/collectors/logger_system_collector.h
@@ -6,6 +6,12 @@
  * @file logger_system_collector.h
  * @brief Metric collector for logger_system log statistics.
  *
+ * @warning Support level: test-only. This header declares the collector
+ *          interface, but no implementation is compiled or linked, the
+ *          collector is not registered in builtin_collectors.h, and it has
+ *          no test. Do not treat it as a usable runtime collector.
+ *          See docs/SUPPORT_STATUS.md.
+ *
  * @see collector_plugin
  */
 

--- a/include/kcenon/monitoring/collectors/plugin_metric_collector.h
+++ b/include/kcenon/monitoring/collectors/plugin_metric_collector.h
@@ -6,6 +6,12 @@
  * @file plugin_metric_collector.h
  * @brief Plugin-based metric collector with dynamic discovery and registration.
  *
+ * @warning Support level: test-only. This header declares the collector
+ *          interface, but no implementation is compiled or linked, the
+ *          collector is not registered in builtin_collectors.h, and it has
+ *          no test. Do not treat it as a usable runtime collector.
+ *          See docs/SUPPORT_STATUS.md.
+ *
  * @see metric_collector_interface
  */
 

--- a/include/kcenon/monitoring/collectors/thread_system_collector.h
+++ b/include/kcenon/monitoring/collectors/thread_system_collector.h
@@ -6,6 +6,12 @@
  * @file thread_system_collector.h
  * @brief Metric collector for thread_system pool and queue statistics.
  *
+ * @warning Support level: test-only. This header declares the collector
+ *          interface, but no implementation is compiled or linked, the
+ *          collector is not registered in builtin_collectors.h, and it has
+ *          no test. Do not treat it as a usable runtime collector.
+ *          See docs/SUPPORT_STATUS.md.
+ *
  * @see thread_to_monitoring_adapter.h
  */
 


### PR DESCRIPTION
## What

`monitoring_system`의 collector / plugin / exporter / placeholder 경로를 감사하여 각 구성요소를 `production` / `experimental` / `test-only` 지원 수준으로 분류했습니다.

- 신규 문서 `docs/SUPPORT_STATUS.md` (`MON-QUAL-006`) — 코드 검증 기반 분류 표
- 문서 레지스트리(`docs/README.md`)에 신규 doc_id 등록
- README, plugin API reference에 support-status 표 링크 추가
- `test-only` stub collector 3종 헤더에 `@warning` doxygen 주석 추가

## Why

README는 본 시스템을 collector·tracing·alerting·plugin·exporter를 갖춘 관측 플랫폼으로 기술하지만, 어떤 구성요소가 production-ready인지 / 인터페이스 스케치인지 구분이 없어 다운스트림 통합 판단이 어려웠습니다. 코드를 SSOT로 삼아 각 구성요소의 실제 구현·빌드 링크·테스트·팩토리 등록 여부를 검증하여 분류했습니다.

## Where

- `docs/SUPPORT_STATUS.md` (신규)
- `docs/README.md` — 레지스트리 등록 (총 81 → 82)
- `README.md` — Collector Factory 섹션에 support-status 안내
- `docs/plugin_api_reference.md` — support-status 안내
- `include/kcenon/monitoring/collectors/{logger_system,thread_system,plugin_metric}_collector.h` — `@warning` 주석

## How

### 감사 방법 (코드 = SSOT)
1. 마커 스윕 — `grep -rni -E "TODO|FIXME|HACK|stub|placeholder|not implemented"` (include 51 / src 12 / tests 69 / benchmarks 7)
2. 구현 확인 — `.cpp` 정의 존재 + `cmake/sources.cmake`의 `GLOB_RECURSE src/*.cpp` 링크 여부
3. 테스트 확인 — `tests/` 전용 테스트 존재 여부
4. 팩토리 확인 — `builtin_collectors.h` 등록 여부

### 분류 결과
- **collector**: production 15 (`collector_base` + 14 런타임 collector), test-only 3
- **plugin**: production 6 (인프라 + container/hardware plugin)
- **exporter**: production 3 (`metric_exporters`, `trace_exporters`, `opentelemetry_adapter`), experimental 4 (transport stub fallback 의존)
- **remove**: 0

`test-only` 3종(`logger_system_collector`, `thread_system_collector`, `plugin_metric_collector`)은 헤더에 인터페이스만 선언되고 구현·테스트·팩토리 등록이 전무하여 라이브러리에 링크되지 않습니다. README/plugin 문서에 production 기능으로 기술된 바는 없으나, 헤더 자체에 `@warning`을 추가하고 follow-up 이슈 #690으로 추적합니다.

`tests`/`benchmarks`의 마커 다수는 무해한 테스트 스캐폴딩으로, support 표에 명시적으로 설명했습니다. collector 내부의 Windows 플랫폼 stub 분기는 문서화된 플랫폼 한계이며 graceful degradation 경로이므로 지원 수준 강등 사유가 아닙니다.

### Follow-up
- #690 — `test-only` stub collector 3종 구현 또는 제거

### Testing
C++ 빌드/테스트는 develop 타겟 PR에서 빌드 매트릭스가 트리거되지 않아 문서 감사 작업에 집중했습니다. 변경은 문서와 헤더 주석에 한정됩니다.

Closes #689
