### PR TITLE
fix(error): remap monitoring_error_code into common reserved -300..-399

### DIFF
--- a/include/kcenon/monitoring/adapters/common_to_monitoring_adapter.h
+++ b/include/kcenon/monitoring/adapters/common_to_monitoring_adapter.h
@@ -58,7 +58,7 @@ public:
         double value) override {
         if (!monitor_) {
             return ::kcenon::common::VoidResult(
-                ::kcenon::common::error_info(1, "Monitor not initialized", "monitoring_system"));
+                ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::monitoring_disabled), "Monitor not initialized", "monitoring_system"));
         }
 
         // Create metric value and add to current collection
@@ -80,7 +80,7 @@ public:
         const std::unordered_map<std::string, std::string>& tags) override {
         if (!monitor_) {
             return ::kcenon::common::VoidResult(
-                ::kcenon::common::error_info(1, "Monitor not initialized", "monitoring_system"));
+                ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::monitoring_disabled), "Monitor not initialized", "monitoring_system"));
         }
 
         metric_value metric(name, value);
@@ -95,12 +95,12 @@ public:
      */
     ::kcenon::common::Result<::kcenon::common::interfaces::metrics_snapshot> get_metrics() override {
         if (!monitor_) {
-            return ::kcenon::common::error_info(1, "Monitor not initialized", "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::monitoring_disabled), "Monitor not initialized", "monitoring_system");
         }
 
         auto result = monitor_->collect_now();
         if (result.is_err()) {
-            return ::kcenon::common::error_info(2, "Failed to collect metrics", "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::collection_failed), "Failed to collect metrics", "monitoring_system");
         }
 
         // Convert monitoring_system snapshot to common snapshot
@@ -127,12 +127,12 @@ public:
      */
     ::kcenon::common::Result<::kcenon::common::interfaces::health_check_result> check_health() override {
         if (!monitor_) {
-            return ::kcenon::common::error_info(1, "Monitor not initialized", "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::monitoring_disabled), "Monitor not initialized", "monitoring_system");
         }
 
         auto result = monitor_->check_health();
         if (result.is_err()) {
-            return ::kcenon::common::error_info(2, "Health check failed", "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::health_check_failed), "Health check failed", "monitoring_system");
         }
 
         // Convert monitoring_system health to common health

--- a/include/kcenon/monitoring/adapters/monitoring_to_common_adapter.h
+++ b/include/kcenon/monitoring/adapters/monitoring_to_common_adapter.h
@@ -91,14 +91,14 @@ public:
      */
     ::kcenon::common::VoidResult record_metric(const std::string& name, double value) override {
         if (!monitor_) {
-            return ::kcenon::common::error_info(1, "Monitor not initialized", "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::monitoring_disabled), "Monitor not initialized", "monitoring_system");
         }
 
         try {
             monitor_->record_metric(name, value);
             return ::kcenon::common::VoidResult(std::monostate{});
         } catch (const std::exception& e) {
-            return ::kcenon::common::error_info(2, e.what(), "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::operation_failed), e.what(), "monitoring_system");
         }
     }
 
@@ -110,7 +110,7 @@ public:
         double value,
         const std::unordered_map<std::string, std::string>& tags) override {
         if (!monitor_) {
-            return ::kcenon::common::error_info(1, "Monitor not initialized", "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::monitoring_disabled), "Monitor not initialized", "monitoring_system");
         }
 
         try {
@@ -118,7 +118,7 @@ public:
             monitor_->record_metric_with_tags(name, value, tags);
             return ::kcenon::common::VoidResult(std::monostate{});
         } catch (const std::exception& e) {
-            return ::kcenon::common::error_info(2, e.what(), "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::operation_failed), e.what(), "monitoring_system");
         }
     }
 
@@ -127,7 +127,7 @@ public:
      */
     ::kcenon::common::Result<::kcenon::common::interfaces::metrics_snapshot> get_metrics() override {
         if (!monitor_) {
-            return ::kcenon::common::error_info(1, "Monitor not initialized", "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::monitoring_disabled), "Monitor not initialized", "monitoring_system");
         }
 
         try {
@@ -148,7 +148,7 @@ public:
             snapshot.source_id = "monitoring_system";
             return snapshot;
         } catch (const std::exception& e) {
-            return ::kcenon::common::error_info(2, e.what(), "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::operation_failed), e.what(), "monitoring_system");
         }
     }
 
@@ -157,7 +157,7 @@ public:
      */
     ::kcenon::common::Result<::kcenon::common::interfaces::health_check_result> check_health() override {
         if (!monitor_) {
-            return ::kcenon::common::error_info(1, "Monitor not initialized", "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::monitoring_disabled), "Monitor not initialized", "monitoring_system");
         }
 
         try {
@@ -177,7 +177,7 @@ public:
 
             return result;
         } catch (const std::exception& e) {
-            return ::kcenon::common::error_info(2, e.what(), "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::operation_failed), e.what(), "monitoring_system");
         }
     }
 
@@ -186,7 +186,7 @@ public:
      */
     ::kcenon::common::VoidResult reset() override {
         if (!monitor_) {
-            return ::kcenon::common::error_info(1, "Monitor not initialized", "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::monitoring_disabled), "Monitor not initialized", "monitoring_system");
         }
 
         try {
@@ -196,7 +196,7 @@ public:
             }
             return ::kcenon::common::VoidResult(std::monostate{});
         } catch (const std::exception& e) {
-            return ::kcenon::common::error_info(2, e.what(), "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::operation_failed), e.what(), "monitoring_system");
         }
     }
 
@@ -332,7 +332,7 @@ public:
      */
     ::kcenon::common::Result<::kcenon::common::interfaces::metrics_snapshot> get_monitoring_data() override {
         if (!monitor_) {
-            return ::kcenon::common::error_info(1, "Monitor not initialized", "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::monitoring_disabled), "Monitor not initialized", "monitoring_system");
         }
 
         try {
@@ -346,7 +346,7 @@ public:
 
             return snapshot;
         } catch (const std::exception& e) {
-            return ::kcenon::common::error_info(2, e.what(), "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::operation_failed), e.what(), "monitoring_system");
         }
     }
 
@@ -370,7 +370,7 @@ public:
 
             return result;
         } catch (const std::exception& e) {
-            return ::kcenon::common::error_info(2, e.what(), "monitoring_system");
+            return ::kcenon::common::error_info(static_cast<int>(monitoring_error_code::operation_failed), e.what(), "monitoring_system");
         }
     }
 

--- a/include/kcenon/monitoring/core/error_codes.h
+++ b/include/kcenon/monitoring/core/error_codes.h
@@ -21,103 +21,118 @@ namespace kcenon { namespace monitoring {
 /**
  * @enum monitoring_error_code
  * @brief Comprehensive error codes for monitoring system operations
+ *
+ * Values are NEGATIVE and confined to the [-399, -300] range that
+ * common_system reserves for monitoring_system (see
+ * kcenon::common::error::category::monitoring_system and the
+ * -300..-399 band documented in common's error_codes.h). Because these
+ * codes are funneled into common's shared error_info.code via
+ * result_types.h::to_common_error() (a plain static_cast<int>), they must
+ * land in common's monitoring band so that
+ * kcenon::common::error::get_category_name() classifies them as
+ * "MonitoringSystem" rather than "Invalid" (any code > 0 is rejected as
+ * invalid after the common classifier change). The underlying type is
+ * therefore SIGNED (std::int32_t).
+ *
+ * The 100-slot window holds 69 distinct negative error codes plus
+ * success (0); unknown_error is pinned to the band floor (-399).
  */
-enum class monitoring_error_code : std::uint32_t {
+enum class monitoring_error_code : std::int32_t {
     // Success
     success = 0,
-    
-    // Collection errors (1000-1999)
-    collector_not_found = 1000,
-    collection_failed = 1001,
-    collector_initialization_failed = 1002,
-    collector_already_exists = 1003,
-    collector_disabled = 1004,
-    invalid_collector_config = 1005,
-    monitoring_disabled = 1006,
-    
-    // Storage errors (2000-2999)
-    storage_full = 2000,
-    storage_corrupted = 2001,
-    compression_failed = 2002,
-    storage_not_initialized = 2003,
-    storage_write_failed = 2004,
-    storage_read_failed = 2005,
-    storage_empty = 2006,
-    
-    // Configuration errors (3000-3999)
-    invalid_configuration = 3000,
-    invalid_interval = 3001,
-    invalid_capacity = 3002,
-    configuration_not_found = 3003,
-    configuration_parse_error = 3004,
-    
-    // System errors (4000-4999)
-    system_resource_unavailable = 4000,
-    permission_denied = 4001,
-    out_of_memory = 4002,
-    memory_allocation_failed = 4003,
-    operation_timeout = 4004,
-    operation_cancelled = 4005,
-    
-    // Integration errors (5000-5999)
-    thread_system_not_available = 5000,
-    logger_system_not_available = 5001,
-    incompatible_version = 5002,
-    adapter_initialization_failed = 5003,
-    
-    // Metrics errors (6000-6999)
-    metric_not_found = 6000,
-    invalid_metric_type = 6001,
-    metric_overflow = 6002,
-    aggregation_failed = 6003,
-    processing_failed = 6004,
-    
-    // Health check errors (7000-7999)
-    health_check_failed = 7000,
-    health_check_timeout = 7001,
-    health_check_not_registered = 7002,
-    
-    // Fault tolerance errors (8000-8099)
-    circuit_breaker_open = 8000,
-    circuit_breaker_half_open = 8001,
-    retry_attempts_exhausted = 8002,
-    operation_failed = 8003,
-    network_error = 8004,
-    service_unavailable = 8005,
-    service_degraded = 8006,
-    error_boundary_triggered = 8007,
-    fallback_failed = 8008,
-    recovery_failed = 8009,
-    
-    // General errors (8100-8999)
-    invalid_argument = 8100,
-    invalid_state = 8101,
-    not_found = 8102,
-    already_exists = 8103,
-    resource_exhausted = 8104,
-    already_started = 8105,
-    dependency_missing = 8106,
-    
-    // Resource management errors (8200-8299)
-    quota_exceeded = 8200,
-    rate_limit_exceeded = 8201,
-    cpu_throttled = 8202,
-    memory_quota_exceeded = 8203,
-    bandwidth_exceeded = 8204,
-    resource_unavailable = 8205,
-    
-    // Data consistency errors (8300-8399)
-    transaction_failed = 8300,
-    transaction_timeout = 8301,
-    transaction_aborted = 8302,
-    validation_failed = 8303,
-    data_corrupted = 8304,
-    state_inconsistent = 8305,
-    deadlock_detected = 8306,
-    rollback_failed = 8307,
-    
-    // Unknown error
-    unknown_error = 9999
+
+    // Collection errors (-300 to -306)
+    collector_not_found = -300,
+    collection_failed = -301,
+    collector_initialization_failed = -302,
+    collector_already_exists = -303,
+    collector_disabled = -304,
+    invalid_collector_config = -305,
+    monitoring_disabled = -306,
+
+    // Storage errors (-310 to -316)
+    storage_full = -310,
+    storage_corrupted = -311,
+    compression_failed = -312,
+    storage_not_initialized = -313,
+    storage_write_failed = -314,
+    storage_read_failed = -315,
+    storage_empty = -316,
+
+    // Configuration errors (-320 to -324)
+    invalid_configuration = -320,
+    invalid_interval = -321,
+    invalid_capacity = -322,
+    configuration_not_found = -323,
+    configuration_parse_error = -324,
+
+    // System errors (-330 to -335)
+    system_resource_unavailable = -330,
+    permission_denied = -331,
+    out_of_memory = -332,
+    memory_allocation_failed = -333,
+    operation_timeout = -334,
+    operation_cancelled = -335,
+
+    // Integration errors (-340 to -343)
+    thread_system_not_available = -340,
+    logger_system_not_available = -341,
+    incompatible_version = -342,
+    adapter_initialization_failed = -343,
+
+    // Metrics errors (-345 to -349)
+    metric_not_found = -345,
+    invalid_metric_type = -346,
+    metric_overflow = -347,
+    aggregation_failed = -348,
+    processing_failed = -349,
+
+    // Health check errors (-350 to -352)
+    health_check_failed = -350,
+    health_check_timeout = -351,
+    health_check_not_registered = -352,
+
+    // Fault tolerance errors (-355 to -364)
+    circuit_breaker_open = -355,
+    circuit_breaker_half_open = -356,
+    retry_attempts_exhausted = -357,
+    operation_failed = -358,
+    network_error = -359,
+    service_unavailable = -360,
+    service_degraded = -361,
+    error_boundary_triggered = -362,
+    fallback_failed = -363,
+    recovery_failed = -364,
+
+    // General errors (-365 to -371)
+    invalid_argument = -365,
+    invalid_state = -366,
+    not_found = -367,
+    already_exists = -368,
+    resource_exhausted = -369,
+    already_started = -370,
+    dependency_missing = -371,
+
+    // Resource management errors (-375 to -380)
+    quota_exceeded = -375,
+    rate_limit_exceeded = -376,
+    cpu_throttled = -377,
+    memory_quota_exceeded = -378,
+    bandwidth_exceeded = -379,
+    resource_unavailable = -380,
+
+    // Data consistency errors (-385 to -392)
+    transaction_failed = -385,
+    transaction_timeout = -386,
+    transaction_aborted = -387,
+    validation_failed = -388,
+    data_corrupted = -389,
+    state_inconsistent = -390,
+    deadlock_detected = -391,
+    rollback_failed = -392,
+
+    // Unknown error (band floor)
+    unknown_error = -399
 };
 
 /**

--- a/src/modules/core.cppm
+++ b/src/modules/core.cppm
@@ -23,6 +23,7 @@ module;
 // Standard library includes (global module fragment)
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -51,24 +52,31 @@ export namespace kcenon::monitoring {
  * @enum monitoring_error_code
  * @brief Error codes for monitoring operations
  */
-enum class monitoring_error_code {
+// Values are NEGATIVE and confined to common_system's reserved
+// monitoring band [-399, -300] so that codes funneled through common's
+// shared error_info.code classify as "MonitoringSystem". Names shared with
+// the header in core/error_codes.h keep identical values; module-only names
+// occupy distinct unused slots inside the band. Underlying type is SIGNED.
+enum class monitoring_error_code : std::int32_t {
     success = 0,
-    invalid_configuration,
-    collector_not_found,
-    metric_not_found,
-    storage_error,
-    export_error,
-    timeout,
-    resource_exhausted,
-    invalid_state,
-    not_initialized,
-    already_initialized,
-    internal_error,
-    invalid_argument,
-    unsupported_operation,
-    permission_denied,
-    network_error,
-    serialization_error
+    // Shared with core/error_codes.h (same value)
+    invalid_configuration = -320,
+    collector_not_found = -300,
+    metric_not_found = -345,
+    resource_exhausted = -369,
+    invalid_state = -366,
+    invalid_argument = -365,
+    permission_denied = -331,
+    network_error = -359,
+    // Module-only names (distinct in-band slots)
+    storage_error = -317,
+    export_error = -344,
+    timeout = -336,
+    not_initialized = -337,
+    already_initialized = -372,
+    internal_error = -398,
+    unsupported_operation = -373,
+    serialization_error = -318
 };
 
 /**

--- a/tests/core/test_result_types.cpp
+++ b/tests/core/test_result_types.cpp
@@ -6,6 +6,7 @@
 #include "kcenon/monitoring/core/result_types.h"
 #include "kcenon/monitoring/core/error_codes.h"
 #include "kcenon/monitoring/interfaces/monitoring_core.h"
+#include <kcenon/common/error/error_codes.h>
 
 using namespace kcenon::monitoring;
 
@@ -153,6 +154,53 @@ TEST_F(ResultTypesTest, MonitoringConfigValidation) {
     result = config.validate();
     EXPECT_FALSE(result.is_ok());
     EXPECT_EQ(static_cast<monitoring_error_code>(result.error().code), monitoring_error_code::invalid_capacity);
+}
+
+/**
+ * @brief Verify monitoring error codes land in common's reserved
+ *        negative band [-399, -300] and classify as "MonitoringSystem".
+ *
+ * Regression guard for issue #697: monitoring_error_code was a positive
+ * enum, which common's classifier (after #698) rejects as "Invalid" because
+ * any code > 0 is out of range. Codes must be negative and within
+ * common_system's reserved monitoring band so they are correctly attributed.
+ */
+TEST_F(ResultTypesTest, ErrorCodesAreInCommonMonitoringBand) {
+    // Representative codes spanning several category sub-bands.
+    const monitoring_error_code samples[] = {
+        monitoring_error_code::collector_not_found,
+        monitoring_error_code::storage_full,
+        monitoring_error_code::invalid_configuration,
+        monitoring_error_code::circuit_breaker_open,
+        monitoring_error_code::transaction_failed,
+        monitoring_error_code::unknown_error,
+    };
+
+    for (auto code : samples) {
+        const int value = static_cast<int>(code);
+        EXPECT_LT(value, 0) << "code must be negative";
+        EXPECT_GE(value, -399) << "code must be >= -399";
+        EXPECT_LE(value, -300) << "code must be <= -300";
+        EXPECT_EQ(kcenon::common::error::get_category_name(value),
+                  "MonitoringSystem")
+            << "common must classify code " << value << " as MonitoringSystem";
+    }
+}
+
+/**
+ * @brief Verify to_common_error() preserves the negative code unchanged
+ *        and that the result classifies as "MonitoringSystem".
+ */
+TEST_F(ResultTypesTest, ToCommonErrorPreservesNegativeCode) {
+    error_info err(monitoring_error_code::collection_failed,
+                   "Failed to collect");
+    kcenon::common::error_info common_err = err.to_common_error();
+
+    EXPECT_EQ(common_err.code,
+              static_cast<int>(monitoring_error_code::collection_failed));
+    EXPECT_LT(common_err.code, 0);
+    EXPECT_EQ(kcenon::common::error::get_category_name(common_err.code),
+              "MonitoringSystem");
 }
 
 TEST_F(ResultTypesTest, HealthCheckResult) {


### PR DESCRIPTION
## What

Remap `monitoring_error_code` from positive values into common's reserved negative band `-300..-399`, so monitoring errors crossing the common boundary classify as "MonitoringSystem" instead of "Success"/"Invalid".

## Why

`monitoring_error_code` was `enum class : std::uint32_t` (1000-9999). `result_types.h::to_common_error()` casts it into common's shared `error_info.code`, and common's classifier reports any non-negative code as "Success" (`>0` as "Invalid" after #698). So every monitoring failure was mis-classified. common reserves `-300..-399` for monitoring. Lands before monitoring's v1.0 tag (it is untagged, so zero SemVer cost).

## How

- Enum underlying type `std::uint32_t` -> `std::int32_t`; all 69 error codes renumbered into `-300..-399` (category-grouped sub-bands; `unknown_error` pinned at `-399`), `success` stays `0`. All values distinct.
- **Adversarial review caught an incomplete first pass**: 19 sites in `adapters/monitoring_to_common_adapter.h` (13) and `adapters/common_to_monitoring_adapter.h` (6) hand-built positive codes (`error_info(1, ...)` / `(2, ...)`) bypassing `to_common_error()`. All now use `static_cast<int>(monitoring_error_code::X)` with in-band negatives (`monitoring_disabled=-306`, `operation_failed=-358`, `collection_failed=-301`, `health_check_failed=-350`).
- Synced the `src/modules/core.cppm` C++20 module enum re-declaration to the header SSOT (it had drifted to a different inline value set — the same dual-SSOT hazard fixed in common's error.cppm).
- Added regression tests asserting representative codes are negative, in `[-399,-300]`, and classify as "MonitoringSystem".

## Verification

monitoring's develop-PR CI runs only integration-tests, so **local full build/test is the authoritative gate**:
- Build PASS (`cmake --preset debug && cmake --build build-debug`).
- ResultTypes + adapter suites 40/40; integration suite 49/49 (incl. `ErrorHandlingTest.ErrorCodeConversion`).
- Full unit suite 1032/1038 — the 6 failures are pre-existing hardware/platform-probe tests (Battery/NetworkInfo/Uptime/MetricsProvider/MetricFactory), unchanged count, none reference error codes (environmental on this host, outside the CI gate).
- Final grep across the tree: zero positive literals passed as a common `error_info` code.

## Where

- `include/kcenon/monitoring/core/error_codes.h`, `src/modules/core.cppm`, `include/kcenon/monitoring/adapters/{monitoring_to_common,common_to_monitoring}_adapter.h`, `tests/core/test_result_types.cpp`

Closes #697
Part of kcenon/monitoring_system#667
