### PR TITLE
docs(changelog): reconcile Unreleased into the v1.0.0 release line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
-
-- Remove the `test-only` `logger_system_collector` and `thread_system_collector`
-  headers, which declared a full collector API with no compiled implementation,
-  no test, and no factory registration. No concrete data source produced their
-  declared statistics, so they were deleted rather than implemented ([#690](https://github.com/kcenon/monitoring_system/issues/690))
-- Remove the unimplemented `plugin_metric_collector` manager class and
-  `plugin_factory` from `collectors/plugin_metric_collector.h`; the header now
-  retains only the production `metric_collector_plugin` interface ([#690](https://github.com/kcenon/monitoring_system/issues/690))
-
-### Changed
-
-- `docs/SUPPORT_STATUS.md` now records zero `test-only` collectors after the
-  resolution of the three stub collectors ([#690](https://github.com/kcenon/monitoring_system/issues/690))
-
 ## [1.0.0] - 2026-04-16
 
 ### Added
@@ -35,10 +20,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CMake export target `monitoring_system::monitoring_system` is now the stable public target name
 - `make_monitor_adapter()` now returns `Result<shared_ptr<IMonitor>>` instead of `shared_ptr<IMonitor>` (breaking change from v0.x)
 - Consolidate 8 bidirectional adapter files into 3 umbrella headers with backward-compatible includes ([#599](https://github.com/kcenon/monitoring_system/issues/599))
+- `docs/SUPPORT_STATUS.md` now records zero `test-only` collectors after the
+  resolution of the three stub collectors ([#690](https://github.com/kcenon/monitoring_system/issues/690))
 
 ### Deprecated
 
 - Throwing constructors in `ring_buffer`, `metric_storage`, `time_series_buffer`, and `performance_monitor_adapter` — use `create()` static factory methods instead
+
+### Removed
+
+- Remove the `test-only` `logger_system_collector` and `thread_system_collector`
+  headers, which declared a full collector API with no compiled implementation,
+  no test, and no factory registration. No concrete data source produced their
+  declared statistics, so they were deleted rather than implemented ([#690](https://github.com/kcenon/monitoring_system/issues/690))
+- Remove the unimplemented `plugin_metric_collector` manager class and
+  `plugin_factory` from `collectors/plugin_metric_collector.h`; the header now
+  retains only the production `metric_collector_plugin` interface ([#690](https://github.com/kcenon/monitoring_system/issues/690))
 
 ## [0.1.0] - 2026-03-11
 


### PR DESCRIPTION
## What

Moved the #690 stub-removal entries from `[Unreleased]` into `[1.0.0]` since v1.0.0 is not yet tagged (the latest tag is v0.1.0). The two `### Removed` bullets and the one `### Changed` bullet now live under `## [1.0.0] - 2026-04-16`, merged into the matching subsections. `[Unreleased]` is kept as an empty header per keep-a-changelog convention.

## Why

Release-prep acceptance item of #698: reconcile the `[Unreleased]` section into the release line. Per keep-a-changelog, changes that have not yet been tagged belong to the pending release. Because v1.0.0 has not been tagged, every `[Unreleased]` entry ships in v1.0.0.

## Note

Kept the existing `[1.0.0] - 2026-04-16` date as-is; the owner adjusts it at tag time.

Part of #667
Relates to #698
