### PR TITLE
fix(ci): repair doc-audit workflow YAML and JS escaping

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -54,16 +54,14 @@ jobs:
           script: |
             const fs = require('fs');
             const reportPath = 'audit-report.md';
-            if (\!fs.existsSync(reportPath)) return;
+            if (!fs.existsSync(reportPath)) return;
             const report = fs.readFileSync(reportPath, 'utf8');
-            if (\!report.trim()) return;
+            if (!report.trim()) return;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `## Documentation Audit Report
-
-${report}`
+              body: `## Documentation Audit Report\n\n${report}`
             });
 
       - name: Fail on critical findings


### PR DESCRIPTION
## What

Fix the `Documentation Audit` workflow (`.github/workflows/doc-audit.yml`),
which fails with a `startup_failure` on every push.

Change type: **fix(ci)** — workflow file only.

## Why

The workflow YAML is unparseable, so GitHub cannot register it and records a
`startup_failure` (jobs=0) for every push event — a persistent red mark across
all branches since the file was added.

Root cause: in the `Comment on PR` step's `actions/github-script` `script:`
block scalar, the `createComment` body is a backtick template literal whose
`${report}` line sits at column 0. That line is less-indented than the block
scalar, so YAML treats it as a new mapping key and fails
(`ScannerError: could not find expected ':'`). A secondary defect: the two
guard lines use the invalid JS escape `\!` instead of `!`.

## Where

`.github/workflows/doc-audit.yml`:
- Inline the comment body to a single line: `` `## Documentation Audit Report\n\n${report}` `` (keeps it inside the block scalar).
- `if (\!fs.existsSync(...))` / `if (\!report.trim())` -> `!` (valid JS).

## How (verification)

`yaml.safe_load` now parses the file (`on: [pull_request]`, `jobs: [audit]`).
After merge, push events no longer create `startup_failure` runs, and the
audit runs as intended on PRs touching `docs/**`, `README*.md`, or `CLAUDE.md`.

This same template defect exists across the kcenon repos; the fix is applied to
each. (The identical file on `main` should receive the same fix via the next
release-merge.)
